### PR TITLE
Add PyTorch Lightning rustlings-style exercises (25–27)

### DIFF
--- a/pytorchlings/EXERCISES.md
+++ b/pytorchlings/EXERCISES.md
@@ -27,3 +27,6 @@
 | 22 | PyG | Train/val/test node masks | `exercises/22_graph_splits/train_val_test_masks.py` | `solutions/22_train_val_test_masks.py` |
 | 23 | PyG | Negative edge sampling | `exercises/23_negative_sampling/negative_edges.py` | `solutions/23_negative_edges.py` |
 | 24 | PyG | Gradient node importance stub | `exercises/24_gnn_explainability/node_importance_stub.py` | `solutions/24_node_importance_stub.py` |
+| 25 | Lightning | LightningModule train/val step | `exercises/25_lightning_module/lightning_module_step.py` | `solutions/25_lightning_module_step.py` |
+| 26 | Lightning | LightningDataModule basics | `exercises/26_lightning_datamodule/datamodule_basics.py` | `solutions/26_datamodule_basics.py` |
+| 27 | Lightning | Trainer + checkpoint smoke setup | `exercises/27_lightning_trainer/trainer_smoke.py` | `solutions/27_trainer_smoke.py` |

--- a/pytorchlings/README.md
+++ b/pytorchlings/README.md
@@ -15,6 +15,7 @@ A rustlings-style practice track for **PyTorch** and **PyTorch Geometric (PyG)**
 - Continue with 10-14 for PyG fundamentals.
 - Extend with 15-19 for more advanced PyTorch practice.
 - Finish 20-24 for advanced PyG workflows.
+- Add 25-27 for PyTorch Lightning abstractions.
 
 ## Quick check command
 
@@ -23,3 +24,8 @@ python -m compileall pytorchlings/exercises pytorchlings/solutions
 ```
 
 > If you do not have PyTorch Geometric installed, complete exercises 00-09 first and treat 10-14 as reading/practice templates.
+
+
+## Lightning note
+
+Exercises 25-27 expect `lightning` to be installed (`pip install lightning`).

--- a/pytorchlings/exercises/25_lightning_module/lightning_module_step.py
+++ b/pytorchlings/exercises/25_lightning_module/lightning_module_step.py
@@ -1,0 +1,23 @@
+"""Exercise 25: build a minimal LightningModule training step."""
+import lightning as L
+import torch
+from torch import nn
+
+
+class LitRegressor(L.LightningModule):
+    def __init__(self, in_features: int = 4, hidden_dim: int = 16, lr: float = 1e-3) -> None:
+        super().__init__()
+        self.save_hyperparameters()
+        # TODO: define a tiny feed-forward network and assign it to self.model
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # TODO: return model predictions
+        raise NotImplementedError
+
+    def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> torch.Tensor:
+        # TODO: unpack batch, compute mse loss, log "train_loss", and return loss
+        raise NotImplementedError
+
+    def configure_optimizers(self) -> torch.optim.Optimizer:
+        # TODO: return Adam optimizer configured with self.hparams.lr
+        raise NotImplementedError

--- a/pytorchlings/exercises/26_lightning_datamodule/datamodule_basics.py
+++ b/pytorchlings/exercises/26_lightning_datamodule/datamodule_basics.py
@@ -1,0 +1,23 @@
+"""Exercise 26: implement a minimal LightningDataModule."""
+import lightning as L
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+
+class ToyRegressionDataModule(L.LightningDataModule):
+    def __init__(self, batch_size: int = 32) -> None:
+        super().__init__()
+        self.batch_size = batch_size
+
+    def setup(self, stage: str | None = None) -> None:
+        # TODO: create a deterministic synthetic regression dataset
+        # TODO: split into train and val TensorDataset objects and assign to self.train_ds/self.val_ds
+        raise NotImplementedError
+
+    def train_dataloader(self) -> DataLoader:
+        # TODO: return train DataLoader with shuffle=True
+        raise NotImplementedError
+
+    def val_dataloader(self) -> DataLoader:
+        # TODO: return val DataLoader with shuffle=False
+        raise NotImplementedError

--- a/pytorchlings/exercises/27_lightning_trainer/trainer_smoke.py
+++ b/pytorchlings/exercises/27_lightning_trainer/trainer_smoke.py
@@ -1,0 +1,14 @@
+"""Exercise 27: configure a Lightning Trainer smoke test."""
+import lightning as L
+from lightning.pytorch.callbacks import ModelCheckpoint
+
+
+def build_trainer(max_epochs: int = 3) -> L.Trainer:
+    # TODO: create a ModelCheckpoint callback monitoring "val_loss" (mode="min")
+    # TODO: return Trainer with logger disabled, checkpointing enabled, and deterministic=True
+    raise NotImplementedError
+
+
+def run_smoke_train(model: L.LightningModule, datamodule: L.LightningDataModule) -> None:
+    trainer = build_trainer(max_epochs=2)
+    trainer.fit(model=model, datamodule=datamodule)

--- a/pytorchlings/solutions/25_lightning_module_step.py
+++ b/pytorchlings/solutions/25_lightning_module_step.py
@@ -1,0 +1,34 @@
+import lightning as L
+import torch
+from torch import nn
+
+
+class LitRegressor(L.LightningModule):
+    def __init__(self, in_features: int = 4, hidden_dim: int = 16, lr: float = 1e-3) -> None:
+        super().__init__()
+        self.save_hyperparameters()
+        self.model = nn.Sequential(
+            nn.Linear(in_features, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.model(x)
+
+    def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> torch.Tensor:
+        x, y = batch
+        pred = self(x)
+        loss = nn.functional.mse_loss(pred, y)
+        self.log("train_loss", loss, prog_bar=True, on_step=True, on_epoch=True)
+        return loss
+
+    def validation_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> torch.Tensor:
+        x, y = batch
+        pred = self(x)
+        loss = nn.functional.mse_loss(pred, y)
+        self.log("val_loss", loss, prog_bar=True, on_step=False, on_epoch=True)
+        return loss
+
+    def configure_optimizers(self) -> torch.optim.Optimizer:
+        return torch.optim.Adam(self.parameters(), lr=self.hparams.lr)

--- a/pytorchlings/solutions/26_datamodule_basics.py
+++ b/pytorchlings/solutions/26_datamodule_basics.py
@@ -1,0 +1,24 @@
+import lightning as L
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+
+
+class ToyRegressionDataModule(L.LightningDataModule):
+    def __init__(self, batch_size: int = 32) -> None:
+        super().__init__()
+        self.batch_size = batch_size
+
+    def setup(self, stage: str | None = None) -> None:
+        generator = torch.Generator().manual_seed(7)
+        x = torch.randn(256, 4, generator=generator)
+        noise = 0.05 * torch.randn(256, 1, generator=generator)
+        y = (x[:, :1] * 0.8) + (x[:, 1:2] * -0.4) + noise
+
+        self.train_ds = TensorDataset(x[:200], y[:200])
+        self.val_ds = TensorDataset(x[200:], y[200:])
+
+    def train_dataloader(self) -> DataLoader:
+        return DataLoader(self.train_ds, batch_size=self.batch_size, shuffle=True)
+
+    def val_dataloader(self) -> DataLoader:
+        return DataLoader(self.val_ds, batch_size=self.batch_size, shuffle=False)

--- a/pytorchlings/solutions/27_trainer_smoke.py
+++ b/pytorchlings/solutions/27_trainer_smoke.py
@@ -1,0 +1,18 @@
+import lightning as L
+from lightning.pytorch.callbacks import ModelCheckpoint
+
+
+def build_trainer(max_epochs: int = 3) -> L.Trainer:
+    checkpoint_cb = ModelCheckpoint(monitor="val_loss", mode="min", save_top_k=1)
+    return L.Trainer(
+        max_epochs=max_epochs,
+        logger=False,
+        deterministic=True,
+        callbacks=[checkpoint_cb],
+        enable_progress_bar=False,
+    )
+
+
+def run_smoke_train(model: L.LightningModule, datamodule: L.LightningDataModule) -> None:
+    trainer = build_trainer(max_epochs=2)
+    trainer.fit(model=model, datamodule=datamodule)


### PR DESCRIPTION
### Motivation
- Extend the existing rustlings-style `pytorchlings` track to cover PyTorch Lightning abstractions so learners can practice `LightningModule`, `LightningDataModule`, and trainer/checkpoint wiring. 
- Provide minimal, self-contained Lightning exercises that mirror the existing PyTorch/PyG flow to make the track more complete. 

### Description
- Add three new exercise skeletons under `pytorchlings/exercises`: `25_lightning_module/lightning_module_step.py`, `26_lightning_datamodule/datamodule_basics.py`, and `27_lightning_trainer/trainer_smoke.py`, each containing `TODO` prompts. 
- Add matching reference solutions in `pytorchlings/solutions`: `solutions/25_lightning_module_step.py`, `solutions/26_datamodule_basics.py`, and `solutions/27_trainer_smoke.py` with working implementations. 
- Update the exercise index `pytorchlings/EXERCISES.md` and `pytorchlings/README.md` to list the new exercises and add a note that exercises 25–27 expect `lightning` to be installed. 

### Testing
- Ran `python -m compileall pytorchlings/exercises pytorchlings/solutions`, which completed successfully. 
- Ran the helper script `python pytorchlings/check.py` to list TODO counts, which executed successfully and reported the new exercises as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6edcce2d0832e9b25bb0e2b4b3778)