### PR TITLE
Add psi4lings rustlings-style quantum chemistry exercises

### DIFF
--- a/psi4lings/EXERCISES.md
+++ b/psi4lings/EXERCISES.md
@@ -1,0 +1,12 @@
+# Exercise List (with solution mapping)
+
+| # | Topic | Exercise File | Solution File |
+|---|---|---|---|
+| 00 | Build a molecule object | `exercises/00_molecule_setup/create_water.py` | `solutions/00_create_water.py` |
+| 01 | RHF single-point energy | `exercises/01_scf_energy/rhf_single_point.py` | `solutions/01_rhf_single_point.py` |
+| 02 | Compare basis sets | `exercises/02_basis_set_scan/basis_comparison.py` | `solutions/02_basis_comparison.py` |
+| 03 | Open-shell UHF setup | `exercises/03_open_shell/uhf_oxygen.py` | `solutions/03_uhf_oxygen.py` |
+| 04 | Geometry optimization | `exercises/04_geometry_optimization/optimize_water.py` | `solutions/04_optimize_water.py` |
+| 05 | Harmonic frequency job | `exercises/05_frequency_analysis/frequencies_water.py` | `solutions/05_frequencies_water.py` |
+| 06 | Compute dipole moment | `exercises/06_properties/dipole_water.py` | `solutions/06_dipole_water.py` |
+| 07 | 1D bond-stretch PES scan | `exercises/07_pes_scan/h2_scan.py` | `solutions/07_h2_scan.py` |

--- a/psi4lings/README.md
+++ b/psi4lings/README.md
@@ -1,0 +1,28 @@
+# psi4lings
+
+A rustlings-style practice track for **Psi4** quantum chemistry workflows.
+
+## How to use
+
+1. Open an exercise in `psi4lings/exercises/...`.
+2. Fill every `TODO` section.
+3. Run the file with Python.
+4. Compare your implementation with the matching answer in `psi4lings/solutions/...`.
+
+## Suggested flow
+
+- Start with 00-01 for molecule setup and first SCF energies.
+- Continue with 02-03 for basis effects and open-shell references.
+- Complete 04-05 to run optimization and vibrational analysis.
+- Finish with 06-07 for molecular properties and a potential-energy scan.
+
+## Quick check command
+
+```bash
+python psi4lings/check.py
+python -m compileall psi4lings/exercises psi4lings/solutions
+```
+
+## Environment note
+
+These exercises assume Psi4 is installed in your Python environment.

--- a/psi4lings/check.py
+++ b/psi4lings/check.py
@@ -1,0 +1,15 @@
+"""Tiny rustlings-like helper: list exercises and count TODOs."""
+from pathlib import Path
+
+
+def main() -> None:
+    root = Path(__file__).parent / "exercises"
+    files = sorted(root.glob("**/*.py"))
+    for file in files:
+        todo_count = file.read_text().count("TODO")
+        status = "✅" if todo_count == 0 else f"🧩 {todo_count} TODOs"
+        print(f"{file.relative_to(root)} -> {status}")
+
+
+if __name__ == "__main__":
+    main()

--- a/psi4lings/exercises/00_molecule_setup/create_water.py
+++ b/psi4lings/exercises/00_molecule_setup/create_water.py
@@ -1,0 +1,19 @@
+"""Exercise 00: build a Psi4 molecule for water."""
+import psi4
+
+
+def run() -> psi4.core.Molecule:
+    # TODO: create a neutral singlet water molecule in C1 symmetry
+    # Hint: use psi4.geometry with an XYZ-style block
+    mol = psi4.geometry("""
+    O
+    H 1 1.0
+    H 1 1.0 2 104.5
+    """)
+
+    # TODO: ensure center-of-mass and orientation are fixed
+    return mol
+
+
+if __name__ == "__main__":
+    print(run().natom())

--- a/psi4lings/exercises/01_scf_energy/rhf_single_point.py
+++ b/psi4lings/exercises/01_scf_energy/rhf_single_point.py
@@ -1,0 +1,25 @@
+"""Exercise 01: run an RHF single-point energy on water."""
+import psi4
+
+
+def run() -> float:
+    mol = psi4.geometry(
+        """
+        0 1
+        O
+        H 1 0.958
+        H 1 0.958 2 104.5
+        symmetry c1
+        """
+    )
+
+    # TODO: set options for RHF/STO-3G and a modest SCF convergence
+    psi4.set_options({})
+
+    # TODO: compute and return the SCF energy as a float
+    energy = 0.0
+    return energy
+
+
+if __name__ == "__main__":
+    print(run())

--- a/psi4lings/exercises/02_basis_set_scan/basis_comparison.py
+++ b/psi4lings/exercises/02_basis_set_scan/basis_comparison.py
@@ -1,0 +1,28 @@
+"""Exercise 02: compare SCF energies across basis sets."""
+import psi4
+
+
+BASIS_SETS = ["sto-3g", "6-31g", "cc-pvdz"]
+
+
+def run() -> dict[str, float]:
+    mol = psi4.geometry(
+        """
+        0 1
+        O
+        H 1 0.958
+        H 1 0.958 2 104.5
+        symmetry c1
+        """
+    )
+
+    energies: dict[str, float] = {}
+    for basis in BASIS_SETS:
+        # TODO: set the basis/reference and compute SCF energy
+        energies[basis] = 0.0
+
+    return energies
+
+
+if __name__ == "__main__":
+    print(run())

--- a/psi4lings/exercises/03_open_shell/uhf_oxygen.py
+++ b/psi4lings/exercises/03_open_shell/uhf_oxygen.py
@@ -1,0 +1,22 @@
+"""Exercise 03: open-shell O2 using UHF."""
+import psi4
+
+
+def run() -> float:
+    # Triplet O2 ground state
+    mol = psi4.geometry(
+        """
+        0 3
+        O
+        O 1 1.21
+        symmetry c1
+        """
+    )
+
+    # TODO: run UHF/6-31G single-point and return the SCF energy
+    psi4.set_options({})
+    return 0.0
+
+
+if __name__ == "__main__":
+    print(run())

--- a/psi4lings/exercises/04_geometry_optimization/optimize_water.py
+++ b/psi4lings/exercises/04_geometry_optimization/optimize_water.py
@@ -1,0 +1,22 @@
+"""Exercise 04: optimize water geometry."""
+import psi4
+
+
+def run() -> float:
+    mol = psi4.geometry(
+        """
+        0 1
+        O
+        H 1 1.10
+        H 1 1.10 2 120.0
+        symmetry c1
+        """
+    )
+
+    # TODO: set basis/reference and run geometry optimization with psi4.optimize
+    final_energy = 0.0
+    return final_energy
+
+
+if __name__ == "__main__":
+    print(run())

--- a/psi4lings/exercises/05_frequency_analysis/frequencies_water.py
+++ b/psi4lings/exercises/05_frequency_analysis/frequencies_water.py
@@ -1,0 +1,23 @@
+"""Exercise 05: run a harmonic frequency analysis."""
+import psi4
+
+
+def run() -> float:
+    mol = psi4.geometry(
+        """
+        0 1
+        O
+        H 1 0.958
+        H 1 0.958 2 104.5
+        symmetry c1
+        """
+    )
+
+    # TODO: run psi4.frequency("scf", return_wfn=True)
+    # TODO: read and return the first harmonic frequency from the wavefunction
+    first_mode_cm1 = 0.0
+    return first_mode_cm1
+
+
+if __name__ == "__main__":
+    print(run())

--- a/psi4lings/exercises/06_properties/dipole_water.py
+++ b/psi4lings/exercises/06_properties/dipole_water.py
@@ -1,0 +1,22 @@
+"""Exercise 06: compute molecular dipole components."""
+import psi4
+
+
+def run() -> tuple[float, float, float]:
+    mol = psi4.geometry(
+        """
+        0 1
+        O
+        H 1 0.958
+        H 1 0.958 2 104.5
+        symmetry c1
+        """
+    )
+
+    # TODO: request dipole properties and run energy with return_wfn=True
+    # TODO: extract and return (mux, muy, muz)
+    return (0.0, 0.0, 0.0)
+
+
+if __name__ == "__main__":
+    print(run())

--- a/psi4lings/exercises/07_pes_scan/h2_scan.py
+++ b/psi4lings/exercises/07_pes_scan/h2_scan.py
@@ -1,0 +1,16 @@
+"""Exercise 07: create a simple H2 bond scan."""
+import psi4
+
+
+def run() -> list[tuple[float, float]]:
+    distances = [0.5, 0.7, 0.9, 1.1, 1.3]
+    results: list[tuple[float, float]] = []
+
+    # TODO: loop over distances, build H2 geometry, and compute RHF/STO-3G energy
+    # TODO: append (distance, energy) to results
+
+    return results
+
+
+if __name__ == "__main__":
+    print(run())

--- a/psi4lings/solutions/00_create_water.py
+++ b/psi4lings/solutions/00_create_water.py
@@ -1,0 +1,21 @@
+"""Solution 00."""
+import psi4
+
+
+def run() -> psi4.core.Molecule:
+    mol = psi4.geometry(
+        """
+        0 1
+        O
+        H 1 0.958
+        H 1 0.958 2 104.5
+        symmetry c1
+        no_reorient
+        no_com
+        """
+    )
+    return mol
+
+
+if __name__ == "__main__":
+    print(run().natom())

--- a/psi4lings/solutions/01_rhf_single_point.py
+++ b/psi4lings/solutions/01_rhf_single_point.py
@@ -1,0 +1,21 @@
+"""Solution 01."""
+import psi4
+
+
+def run() -> float:
+    mol = psi4.geometry(
+        """
+        0 1
+        O
+        H 1 0.958
+        H 1 0.958 2 104.5
+        symmetry c1
+        """
+    )
+    psi4.set_options({"basis": "sto-3g", "reference": "rhf", "e_convergence": 1e-8})
+    energy = psi4.energy("scf", molecule=mol)
+    return float(energy)
+
+
+if __name__ == "__main__":
+    print(run())

--- a/psi4lings/solutions/02_basis_comparison.py
+++ b/psi4lings/solutions/02_basis_comparison.py
@@ -1,0 +1,27 @@
+"""Solution 02."""
+import psi4
+
+
+BASIS_SETS = ["sto-3g", "6-31g", "cc-pvdz"]
+
+
+def run() -> dict[str, float]:
+    mol = psi4.geometry(
+        """
+        0 1
+        O
+        H 1 0.958
+        H 1 0.958 2 104.5
+        symmetry c1
+        """
+    )
+
+    energies: dict[str, float] = {}
+    for basis in BASIS_SETS:
+        psi4.set_options({"basis": basis, "reference": "rhf"})
+        energies[basis] = float(psi4.energy("scf", molecule=mol))
+    return energies
+
+
+if __name__ == "__main__":
+    print(run())

--- a/psi4lings/solutions/03_uhf_oxygen.py
+++ b/psi4lings/solutions/03_uhf_oxygen.py
@@ -1,0 +1,19 @@
+"""Solution 03."""
+import psi4
+
+
+def run() -> float:
+    mol = psi4.geometry(
+        """
+        0 3
+        O
+        O 1 1.21
+        symmetry c1
+        """
+    )
+    psi4.set_options({"basis": "6-31g", "reference": "uhf", "d_convergence": 1e-8})
+    return float(psi4.energy("scf", molecule=mol))
+
+
+if __name__ == "__main__":
+    print(run())

--- a/psi4lings/solutions/04_optimize_water.py
+++ b/psi4lings/solutions/04_optimize_water.py
@@ -1,0 +1,21 @@
+"""Solution 04."""
+import psi4
+
+
+def run() -> float:
+    mol = psi4.geometry(
+        """
+        0 1
+        O
+        H 1 1.10
+        H 1 1.10 2 120.0
+        symmetry c1
+        """
+    )
+    psi4.set_options({"basis": "6-31g", "reference": "rhf", "g_convergence": "gau_tight"})
+    final_energy = psi4.optimize("scf", molecule=mol)
+    return float(final_energy)
+
+
+if __name__ == "__main__":
+    print(run())

--- a/psi4lings/solutions/05_frequencies_water.py
+++ b/psi4lings/solutions/05_frequencies_water.py
@@ -1,0 +1,23 @@
+"""Solution 05."""
+import psi4
+
+
+def run() -> float:
+    mol = psi4.geometry(
+        """
+        0 1
+        O
+        H 1 0.958
+        H 1 0.958 2 104.5
+        symmetry c1
+        """
+    )
+    psi4.set_options({"basis": "sto-3g", "reference": "rhf"})
+    _, wfn = psi4.frequency("scf", molecule=mol, return_wfn=True)
+    frequencies = wfn.frequencies().to_array()
+    positive_freqs = [f for f in frequencies if f > 1.0]
+    return float(positive_freqs[0])
+
+
+if __name__ == "__main__":
+    print(run())

--- a/psi4lings/solutions/06_dipole_water.py
+++ b/psi4lings/solutions/06_dipole_water.py
@@ -1,0 +1,25 @@
+"""Solution 06."""
+import psi4
+
+
+def run() -> tuple[float, float, float]:
+    mol = psi4.geometry(
+        """
+        0 1
+        O
+        H 1 0.958
+        H 1 0.958 2 104.5
+        symmetry c1
+        """
+    )
+    psi4.set_options({"basis": "6-31g", "reference": "rhf"})
+    _, wfn = psi4.energy("scf", molecule=mol, return_wfn=True)
+    psi4.oeprop(wfn, "DIPOLE")
+    mux = float(wfn.variable("SCF DIPOLE X"))
+    muy = float(wfn.variable("SCF DIPOLE Y"))
+    muz = float(wfn.variable("SCF DIPOLE Z"))
+    return (mux, muy, muz)
+
+
+if __name__ == "__main__":
+    print(run())

--- a/psi4lings/solutions/07_h2_scan.py
+++ b/psi4lings/solutions/07_h2_scan.py
@@ -1,0 +1,26 @@
+"""Solution 07."""
+import psi4
+
+
+def run() -> list[tuple[float, float]]:
+    distances = [0.5, 0.7, 0.9, 1.1, 1.3]
+    results: list[tuple[float, float]] = []
+
+    psi4.set_options({"basis": "sto-3g", "reference": "rhf"})
+    for distance in distances:
+        mol = psi4.geometry(
+            f"""
+            0 1
+            H
+            H 1 {distance}
+            symmetry c1
+            """
+        )
+        energy = float(psi4.energy("scf", molecule=mol))
+        results.append((distance, energy))
+
+    return results
+
+
+if __name__ == "__main__":
+    print(run())


### PR DESCRIPTION
### Motivation
- Provide a rustlings-like practice track for Psi4 so learners can complete small, guided quantum chemistry tasks in a hands-on way.
- Cover common Psi4 workflows (molecule construction, SCF energies, basis scans, open-shell handling, geometry optimization, frequencies, dipole moments, and PES scans) in a progressive 00→07 sequence.
- Offer the same ergonomics as the existing `pytorchlings` track: lightweight exercises with `TODO` slots and matching solution files.

### Description
- Add a new `psi4lings` training track with `README.md` and `EXERCISES.md` documenting usage and the exercise→solution mapping.
- Add a rustlings-like helper `psi4lings/check.py` that scans `exercises/` and reports remaining `TODO` counts.
- Add 8 exercise templates (`exercises/00_...` through `exercises/07_...`) that contain `TODO` prompts for common Psi4 jobs and matching fully-implemented solution files in `psi4lings/solutions/`.
- Clean up generated `__pycache__` files and include the track in the repository (files staged and committed).

### Testing
- Ran `python psi4lings/check.py` to validate the exercise helper runs and reports TODO counts; the script executed successfully.
- Ran `python -m compileall psi4lings/exercises psi4lings/solutions` to verify all new modules compile; compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6f28a48f0832e8c150c57101fad86)