### PR TITLE
Add rustlings-style py03 exercise track

### DIFF
--- a/py03lings/EXERCISES.md
+++ b/py03lings/EXERCISES.md
@@ -1,0 +1,8 @@
+# Exercise List (with solution mapping)
+
+| # | Topic | Exercise File | Solution File |
+|---|---|---|---|
+| 00 | f-strings and joins | `exercises/00_string_builder/string_builder.py` | `solutions/00_string_builder.py` |
+| 01 | conditionals and loops | `exercises/01_control_flow/control_flow.py` | `solutions/01_control_flow.py` |
+| 02 | list/dict transformations | `exercises/02_collections/collections_ops.py` | `solutions/02_collections_ops.py` |
+| 03 | function defaults and kwargs | `exercises/03_functions/keyword_report.py` | `solutions/03_keyword_report.py` |

--- a/py03lings/README.md
+++ b/py03lings/README.md
@@ -1,0 +1,17 @@
+# py03lings
+
+A rustlings-style practice track for Python 3 fundamentals.
+
+## How to use
+
+1. Open an exercise in `py03lings/exercises/...`.
+2. Fill every `TODO` section.
+3. Run the file with Python.
+4. Compare with the matching answer in `py03lings/solutions/...`.
+
+## Quick check commands
+
+```bash
+python py03lings/check.py
+python -m compileall py03lings/exercises py03lings/solutions
+```

--- a/py03lings/check.py
+++ b/py03lings/check.py
@@ -1,0 +1,15 @@
+"""Tiny rustlings-like helper: list exercises and count TODOs."""
+from pathlib import Path
+
+
+def main() -> None:
+    root = Path(__file__).parent / "exercises"
+    files = sorted(root.glob("**/*.py"))
+    for file in files:
+        todo_count = file.read_text().count("TODO")
+        status = "✅" if todo_count == 0 else f"🧩 {todo_count} TODOs"
+        print(f"{file.relative_to(root)} -> {status}")
+
+
+if __name__ == "__main__":
+    main()

--- a/py03lings/exercises/00_string_builder/string_builder.py
+++ b/py03lings/exercises/00_string_builder/string_builder.py
@@ -1,0 +1,12 @@
+"""Exercise 00: build a comma-separated summary with f-strings."""
+
+
+def summarize_student(name: str, score: int, topics: list[str]) -> str:
+    # TODO: return exactly: "{name} scored {score} in {topic1, topic2, ...}"
+    # TODO: if topics is empty, use "no topics"
+    topics_text = ""
+    return f"{name} scored {score} in {topics_text}"
+
+
+if __name__ == "__main__":
+    print(summarize_student("Ada", 93, ["loops", "dicts", "functions"]))

--- a/py03lings/exercises/01_control_flow/control_flow.py
+++ b/py03lings/exercises/01_control_flow/control_flow.py
@@ -1,0 +1,14 @@
+"""Exercise 01: classify numbers with control flow."""
+
+
+def classify_numbers(values: list[int]) -> dict[str, int]:
+    """Return counts for positive, negative, and zero."""
+    counts = {"positive": 0, "negative": 0, "zero": 0}
+    for value in values:
+        # TODO: increment exactly one bucket based on sign
+        pass
+    return counts
+
+
+if __name__ == "__main__":
+    print(classify_numbers([3, -1, 0, 7, 0, -9]))

--- a/py03lings/exercises/02_collections/collections_ops.py
+++ b/py03lings/exercises/02_collections/collections_ops.py
@@ -1,0 +1,14 @@
+"""Exercise 02: convert rows into a lookup table."""
+
+
+def build_price_lookup(rows: list[tuple[str, float]]) -> dict[str, float]:
+    """Keep the latest price for each item name."""
+    lookup: dict[str, float] = {}
+    # TODO: fill lookup from rows
+    # hint: later rows should overwrite earlier rows with the same key
+    return lookup
+
+
+if __name__ == "__main__":
+    data = [("NaCl", 10.5), ("H2O", 1.0), ("NaCl", 11.0)]
+    print(build_price_lookup(data))

--- a/py03lings/exercises/03_functions/keyword_report.py
+++ b/py03lings/exercises/03_functions/keyword_report.py
@@ -1,0 +1,13 @@
+"""Exercise 03: use defaults, *args, and **kwargs."""
+
+
+def format_report(title: str, *items: str, uppercase: bool = False, **meta: str) -> str:
+    # TODO: Build body from items joined by "; " (or "(none)" if empty)
+    # TODO: Build metadata as "key=value" pairs sorted by key, joined by ", "
+    # TODO: Final format: "[{title}] {body} | {metadata}"
+    # TODO: If uppercase=True, uppercase the entire final string
+    return ""
+
+
+if __name__ == "__main__":
+    print(format_report("Lab", "prep", "mix", owner="alex", room="B12"))

--- a/py03lings/solutions/00_string_builder.py
+++ b/py03lings/solutions/00_string_builder.py
@@ -1,0 +1,10 @@
+"""Solution 00: build a comma-separated summary with f-strings."""
+
+
+def summarize_student(name: str, score: int, topics: list[str]) -> str:
+    topics_text = ", ".join(topics) if topics else "no topics"
+    return f"{name} scored {score} in {topics_text}"
+
+
+if __name__ == "__main__":
+    print(summarize_student("Ada", 93, ["loops", "dicts", "functions"]))

--- a/py03lings/solutions/01_control_flow.py
+++ b/py03lings/solutions/01_control_flow.py
@@ -1,0 +1,17 @@
+"""Solution 01: classify numbers with control flow."""
+
+
+def classify_numbers(values: list[int]) -> dict[str, int]:
+    counts = {"positive": 0, "negative": 0, "zero": 0}
+    for value in values:
+        if value > 0:
+            counts["positive"] += 1
+        elif value < 0:
+            counts["negative"] += 1
+        else:
+            counts["zero"] += 1
+    return counts
+
+
+if __name__ == "__main__":
+    print(classify_numbers([3, -1, 0, 7, 0, -9]))

--- a/py03lings/solutions/02_collections_ops.py
+++ b/py03lings/solutions/02_collections_ops.py
@@ -1,0 +1,13 @@
+"""Solution 02: convert rows into a lookup table."""
+
+
+def build_price_lookup(rows: list[tuple[str, float]]) -> dict[str, float]:
+    lookup: dict[str, float] = {}
+    for item, price in rows:
+        lookup[item] = price
+    return lookup
+
+
+if __name__ == "__main__":
+    data = [("NaCl", 10.5), ("H2O", 1.0), ("NaCl", 11.0)]
+    print(build_price_lookup(data))

--- a/py03lings/solutions/03_keyword_report.py
+++ b/py03lings/solutions/03_keyword_report.py
@@ -1,0 +1,12 @@
+"""Solution 03: use defaults, *args, and **kwargs."""
+
+
+def format_report(title: str, *items: str, uppercase: bool = False, **meta: str) -> str:
+    body = "; ".join(items) if items else "(none)"
+    metadata = ", ".join(f"{k}={v}" for k, v in sorted(meta.items()))
+    output = f"[{title}] {body} | {metadata}"
+    return output.upper() if uppercase else output
+
+
+if __name__ == "__main__":
+    print(format_report("Lab", "prep", "mix", owner="alex", room="B12"))


### PR DESCRIPTION
### Motivation
- Provide a small rustlings-style learning track for Python 3 fundamentals to mirror existing `*lings` tracks. 
- Offer scaffolded exercises that teach common beginner topics (f-strings, control flow, collections, function args). 
- Include a lightweight helper to let instructors and learners quickly see which exercises still contain `TODO`s.

### Description
- Add a new `py03lings` directory containing `README.md` and `EXERCISES.md` with usage notes and an exercise-to-solution index. 
- Add `check.py` which scans `py03lings/exercises` for `TODO` markers and reports per-file status. 
- Add four scaffolded exercises under `py03lings/exercises` (`00`–`03`) covering string building, control flow, collections, and function argument patterns. 
- Add matching reference solutions under `py03lings/solutions` for each scaffolded exercise.

### Testing
- Ran `python py03lings/check.py` which executed and reported TODO counts for the new exercises. 
- Ran `python -m compileall py03lings/exercises py03lings/solutions` which compiled the exercises and solution modules without errors. 
- Both automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd4a4cda28832e9bd2035ba7a680d7)