### PR TITLE
Add PyG GraphGym practice exercises to pytorchlings

### DIFF
--- a/pytorchlings/EXERCISES.md
+++ b/pytorchlings/EXERCISES.md
@@ -37,3 +37,6 @@
 | 32 | NetworkX | Directed predecessors/successors + reachability | `exercises/32_nx_directed_graphs/nx_directed_graphs.py` | `solutions/32_nx_directed_graphs.py` |
 | 33 | NetworkX | Bipartite graph + projections | `exercises/33_nx_bipartite_basics/nx_bipartite_basics.py` | `solutions/33_nx_bipartite_basics.py` |
 | 34 | NetworkX | Cycle detection + tree check | `exercises/34_nx_cycles_and_trees/nx_cycles_and_trees.py` | `solutions/34_nx_cycles_and_trees.py` |
+| 35 | PyG | GraphGym config basics | `exercises/35_graphgym_config/graphgym_config.py` | `solutions/35_graphgym_config.py` |
+| 36 | PyG | GraphGym custom pooling registration | `exercises/36_graphgym_register/register_pooling.py` | `solutions/36_register_pooling.py` |
+| 37 | PyG | GraphGym YAML experiment setup | `exercises/37_graphgym_yaml/build_experiment_yaml.py` | `solutions/37_graphgym_yaml.py` |

--- a/pytorchlings/README.md
+++ b/pytorchlings/README.md
@@ -18,6 +18,7 @@ A rustlings-style practice track for **PyTorch** and **PyTorch Geometric (PyG)**
 - Add 25-27 for PyTorch Lightning abstractions.
 - Finish with 28-30 for NetworkX `nx.Graph` practice.
 - Continue 31-34 for weighted, directed, bipartite, and cycle/tree graph workflows.
+- Add 35-37 for PyG GraphGym config, registration, and experiment YAML practice.
 
 ## Quick check command
 

--- a/pytorchlings/exercises/35_graphgym_config/graphgym_config.py
+++ b/pytorchlings/exercises/35_graphgym_config/graphgym_config.py
@@ -1,0 +1,14 @@
+"""Exercise 35: build a minimal GraphGym config with PyG defaults."""
+from torch_geometric.graphgym.config import cfg, set_cfg
+
+
+def build_graphgym_cfg() -> object:
+    """Return a GraphGym cfg object configured for a tiny GNN experiment."""
+    set_cfg(cfg)
+
+    # TODO: set cfg.dataset.name to "Cora"
+    # TODO: set cfg.model.type to "gcn"
+    # TODO: set cfg.gnn.layers_mp to 2
+    # TODO: set cfg.optim.max_epoch to 50
+
+    return cfg

--- a/pytorchlings/exercises/36_graphgym_register/register_pooling.py
+++ b/pytorchlings/exercises/36_graphgym_register/register_pooling.py
@@ -1,0 +1,14 @@
+"""Exercise 36: register a custom GraphGym global pooling op."""
+import torch
+from torch_geometric.graphgym.register import register_pooling
+
+
+def mean_abs_pool(x: torch.Tensor, batch: torch.Tensor) -> torch.Tensor:
+    """Pool by graph using mean of absolute node embeddings."""
+    # TODO: return scatter mean(abs(x)) grouped by batch
+    # Hint: use torch_geometric.utils.scatter with reduce="mean"
+    return x
+
+
+# TODO: register the function above under the name "mean_abs"
+register_pooling("todo_mean_abs", mean_abs_pool)

--- a/pytorchlings/exercises/37_graphgym_yaml/build_experiment_yaml.py
+++ b/pytorchlings/exercises/37_graphgym_yaml/build_experiment_yaml.py
@@ -1,0 +1,10 @@
+"""Exercise 37: create a GraphGym YAML experiment string."""
+
+
+def graphgym_yaml() -> str:
+    """Return a YAML string for a quick GraphGym run on Cora."""
+    # TODO: include dataset.name: Cora
+    # TODO: include model.type: gcn
+    # TODO: include gnn.layers_mp: 2
+    # TODO: include optim.max_epoch: 50
+    return ""

--- a/pytorchlings/solutions/35_graphgym_config.py
+++ b/pytorchlings/solutions/35_graphgym_config.py
@@ -1,0 +1,11 @@
+from torch_geometric.graphgym.config import cfg, set_cfg
+
+
+def build_graphgym_cfg() -> object:
+    """Return a GraphGym cfg object configured for a tiny GNN experiment."""
+    set_cfg(cfg)
+    cfg.dataset.name = "Cora"
+    cfg.model.type = "gcn"
+    cfg.gnn.layers_mp = 2
+    cfg.optim.max_epoch = 50
+    return cfg

--- a/pytorchlings/solutions/36_register_pooling.py
+++ b/pytorchlings/solutions/36_register_pooling.py
@@ -1,0 +1,11 @@
+import torch
+from torch_geometric.graphgym.register import register_pooling
+from torch_geometric.utils import scatter
+
+
+def mean_abs_pool(x: torch.Tensor, batch: torch.Tensor) -> torch.Tensor:
+    """Pool by graph using mean of absolute node embeddings."""
+    return scatter(x.abs(), batch, dim=0, reduce="mean")
+
+
+register_pooling("mean_abs", mean_abs_pool)

--- a/pytorchlings/solutions/37_graphgym_yaml.py
+++ b/pytorchlings/solutions/37_graphgym_yaml.py
@@ -1,0 +1,14 @@
+def graphgym_yaml() -> str:
+    """Return a YAML string for a quick GraphGym run on Cora."""
+    return "\n".join(
+        [
+            "dataset:",
+            "  name: Cora",
+            "model:",
+            "  type: gcn",
+            "gnn:",
+            "  layers_mp: 2",
+            "optim:",
+            "  max_epoch: 50",
+        ]
+    )


### PR DESCRIPTION
### Motivation
- Expand the PyG portion of the `pytorchlings` track with hands-on GraphGym practice covering config, custom pooling registration, and YAML experiment setup.
- Provide instructors and learners minimal exercises that demonstrate how to configure GraphGym, register custom pooling ops, and serialize a small experiment spec.

### Description
- Add three new exercise stubs: `pytorchlings/exercises/35_graphgym_config/graphgym_config.py`, `pytorchlings/exercises/36_graphgym_register/register_pooling.py`, and `pytorchlings/exercises/37_graphgym_yaml/build_experiment_yaml.py` with `TODO` prompts for learners.
- Add matching solution files: `pytorchlings/solutions/35_graphgym_config.py`, `pytorchlings/solutions/36_register_pooling.py`, and `pytorchlings/solutions/37_graphgym_yaml.py` implementing the expected GraphGym config, pooling registration, and YAML output.
- Update the exercises index `pytorchlings/EXERCISES.md` to include entries for exercises 35–37 and update `pytorchlings/README.md` suggested flow to mention the new GraphGym segment.

### Testing
- Ran `python -m compileall pytorchlings/exercises pytorchlings/solutions` which completed successfully.
- Ran `python pytorchlings/check.py` to list exercises and TODO counts, which executed successfully and included the new exercises in its output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0fb8f995c832eba67e1b2ee541ff2)