### PR TITLE
Add PyO3-focused exercises and starter APIs to practical-rustlings

### DIFF
--- a/practical-rustlings/EXERCISES.md
+++ b/practical-rustlings/EXERCISES.md
@@ -1,4 +1,4 @@
-# Practical Rustlings Exercises (20)
+# Practical Rustlings Exercises (25)
 
 These exercises are grouped by the skill gaps identified in your assessment.
 
@@ -160,6 +160,45 @@ These exercises are grouped by the skill gaps identified in your assessment.
   - unit/invariant strategy.
 
 **Done when:** another developer can understand and extend your design quickly.
+
+---
+
+## Track F — PyO3 / Python Interop from Rust
+
+### 21) `pyo3-function-signatures`
+**Focus:** ergonomic Python-callable signatures.
+- Design a `#[pyfunction]` API using `&str`, `Vec<f64>`, and optional keyword arguments.
+- Compare one strict signature and one permissive signature.
+
+**Done when:** call sites in Python are clear and Rust-side error cases are explicit.
+
+### 22) `python-index-semantics`
+**Focus:** Python negative-index behavior in Rust.
+- Implement index normalization (`-1` means last element, etc.).
+- Return clear errors for out-of-bounds access.
+
+**Done when:** tests cover positive, negative, and invalid indexes.
+
+### 23) `overflow-to-pyerr`
+**Focus:** safe arithmetic surfaced as Python exceptions.
+- Build a Rust helper using checked arithmetic.
+- Map overflow to a Python-facing error shape.
+
+**Done when:** overflow branches are test-covered and produce useful messages.
+
+### 24) `kwargs-validation`
+**Focus:** validating dynamic Python input.
+- Accept a dict-like structure (`kwargs`) with required/optional keys.
+- Convert and validate numbers (for example positive-only).
+
+**Done when:** missing keys, wrong types, and invalid ranges are distinguishable.
+
+### 25) `vectorized-bridge`
+**Focus:** batch operations over Python lists/tuples.
+- Implement a Rust batch transform suitable for `#[pyfunction]`.
+- Avoid unnecessary cloning and support empty inputs.
+
+**Done when:** function handles large inputs efficiently and tests include edge cases.
 
 ---
 

--- a/practical-rustlings/src/exercises.rs
+++ b/practical-rustlings/src/exercises.rs
@@ -7,6 +7,9 @@ pub enum SimError {
     UnitMismatch,
     NonConvergent,
     InvalidTransition,
+    Overflow,
+    MissingField,
+    OutOfBounds,
 }
 
 // 1) ok-or-not-ok
@@ -205,4 +208,89 @@ pub fn run_steps<I: Integrator>(integrator: &I, mut x: f64, v: f64, dt: f64, n: 
         x = integrator.integrate(x, v, dt);
     }
     x
+}
+
+// 21) pyo3-function-signatures
+pub fn pyo3_scale(values: &[f64], scale: Option<f64>) -> Vec<f64> {
+    let factor = scale.unwrap_or(1.0);
+    values.iter().map(|v| v * factor).collect()
+}
+
+// 22) python-index-semantics
+pub fn normalize_py_index(len: usize, index: isize) -> Result<usize, SimError> {
+    if len == 0 {
+        return Err(SimError::OutOfBounds);
+    }
+    let len_isize = len as isize;
+    let normalized = if index < 0 { len_isize + index } else { index };
+    if normalized >= 0 && normalized < len_isize {
+        Ok(normalized as usize)
+    } else {
+        Err(SimError::OutOfBounds)
+    }
+}
+
+// 23) overflow-to-pyerr
+pub fn checked_sum_i64(values: &[i64]) -> Result<i64, SimError> {
+    values.iter().try_fold(0_i64, |acc, &v| {
+        acc.checked_add(v).ok_or(SimError::Overflow)
+    })
+}
+
+// 24) kwargs-validation
+pub fn required_positive_arg(
+    kwargs: &std::collections::HashMap<String, f64>,
+    key: &str,
+) -> Result<f64, SimError> {
+    let value = kwargs.get(key).copied().ok_or(SimError::MissingField)?;
+    if value > 0.0 {
+        Ok(value)
+    } else {
+        Err(SimError::UnitMismatch)
+    }
+}
+
+// 25) vectorized-bridge
+pub fn batch_square(values: &[i64]) -> Vec<i64> {
+    values.iter().map(|v| v * v).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn normalizes_python_index() {
+        assert_eq!(normalize_py_index(4, 0), Ok(0));
+        assert_eq!(normalize_py_index(4, -1), Ok(3));
+        assert_eq!(normalize_py_index(4, -4), Ok(0));
+        assert_eq!(normalize_py_index(4, 4), Err(SimError::OutOfBounds));
+        assert_eq!(normalize_py_index(0, 0), Err(SimError::OutOfBounds));
+    }
+
+    #[test]
+    fn catches_checked_sum_overflow() {
+        assert_eq!(checked_sum_i64(&[1, 2, 3]), Ok(6));
+        assert_eq!(checked_sum_i64(&[i64::MAX, 1]), Err(SimError::Overflow));
+    }
+
+    #[test]
+    fn validates_required_positive_kwargs() {
+        let mut kwargs = HashMap::new();
+        kwargs.insert("temperature_k".to_string(), 300.0);
+        assert_eq!(
+            required_positive_arg(&kwargs, "temperature_k"),
+            Ok(300.0)
+        );
+        assert_eq!(
+            required_positive_arg(&kwargs, "pressure"),
+            Err(SimError::MissingField)
+        );
+        kwargs.insert("temperature_k".to_string(), 0.0);
+        assert_eq!(
+            required_positive_arg(&kwargs, "temperature_k"),
+            Err(SimError::UnitMismatch)
+        );
+    }
 }


### PR DESCRIPTION
### Motivation
- Expand the Practical Rustlings track to include Python interoperability topics so Rust learners can practice designing `#[pyfunction]`-style APIs and common Python semantics in Rust.
- Provide small, well-scoped starter surfaces that demonstrate how to normalize Python index semantics, map arithmetic overflow to errors, validate kwargs-style inputs, and implement efficient batch transforms.

### Description
- Updated `practical-rustlings/EXERCISES.md` to increase the exercise count from 20 to 25 and added a new "Track F — PyO3 / Python Interop from Rust" with exercises 21–25 (`pyo3-function-signatures`, `python-index-semantics`, `overflow-to-pyerr`, `kwargs-validation`, `vectorized-bridge`).
- Extended `practical-rustlings/src/exercises.rs` by adding new `SimError` variants (`Overflow`, `MissingField`, `OutOfBounds`) and starter implementations: `pyo3_scale`, `normalize_py_index`, `checked_sum_i64`, `required_positive_arg`, and `batch_square`.
- Added unit tests for Python-style index normalization, checked-sum overflow detection, and kwargs validation directly in `practical-rustlings/src/exercises.rs`.
- No new dependencies were introduced; these are Rust-side helper surfaces intended to be wired into `pyo3` modules in follow-up work.

### Testing
- Ran `cd practical-rustlings && cargo test` to execute the crate test suite.
- All tests succeeded: `6` unit tests passed and `0` failed (test run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c25aa55c14832e93b8fb4542e2ebaf)