### PR TITLE
Add advanced_patterns exercises (24_advanced_patterns) with implementations and tests

### DIFF
--- a/practical-rustlings/24_advanced_patterns/README.md
+++ b/practical-rustlings/24_advanced_patterns/README.md
@@ -1,0 +1,20 @@
+# Advanced patterns (extra set)
+
+These are 10 additional exercises focused on advanced Rust patterns. They are intentionally a bit more open-ended than early rustlings-style drills.
+
+1. `advanced_patterns1_arc_mutex.rs` — shared mutable counter with `Arc<Mutex<_>>`
+2. `advanced_patterns2_rwlock_cache.rs` — read-heavy cache with `RwLock`
+3. `advanced_patterns3_mpsc_fan_in.rs` — multiple producers into one consumer
+4. `advanced_patterns4_scoped_threads.rs` — borrowing into scoped threads
+5. `advanced_patterns5_condvar_queue.rs` — blocking queue with `Condvar`
+6. `advanced_patterns6_pin_basics.rs` — pinning and stable address checks
+7. `advanced_patterns7_retry_backoff.rs` — retries with incremental backoff
+8. `advanced_patterns8_cow_normalize.rs` — avoid allocations via `Cow<'_, str>`
+9. `advanced_patterns9_ffi_guard.rs` — safe wrapper around nullable C string pointers
+10. `advanced_patterns10_state_machine.rs` — typed state transition API
+
+## Further reading
+
+- [The Rust Book — Fearless Concurrency](https://doc.rust-lang.org/book/ch16-00-concurrency.html)
+- [The Rustonomicon](https://doc.rust-lang.org/nomicon/)
+- [std::pin](https://doc.rust-lang.org/std/pin/index.html)

--- a/practical-rustlings/24_advanced_patterns/advanced_patterns10_state_machine.rs
+++ b/practical-rustlings/24_advanced_patterns/advanced_patterns10_state_machine.rs
@@ -1,0 +1,61 @@
+// Model a tiny typed state machine.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Initialized;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Running;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Finished;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Sim<S> {
+    step: usize,
+    state: S,
+}
+
+impl Sim<Initialized> {
+    pub fn new() -> Self {
+        Self {
+            step: 0,
+            state: Initialized,
+        }
+    }
+
+    pub fn start(self) -> Sim<Running> {
+        Sim {
+            step: self.step,
+            state: Running,
+        }
+    }
+}
+
+impl Sim<Running> {
+    pub fn advance(mut self) -> Self {
+        self.step += 1;
+        self
+    }
+
+    pub fn finish(self) -> Sim<Finished> {
+        Sim {
+            step: self.step,
+            state: Finished,
+        }
+    }
+}
+
+impl Sim<Finished> {
+    pub fn steps(&self) -> usize {
+        self.step
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn typed_transitions_work() {
+        let done = Sim::new().start().advance().advance().finish();
+        assert_eq!(done.steps(), 2);
+    }
+}

--- a/practical-rustlings/24_advanced_patterns/advanced_patterns1_arc_mutex.rs
+++ b/practical-rustlings/24_advanced_patterns/advanced_patterns1_arc_mutex.rs
@@ -1,0 +1,39 @@
+// Build a thread-safe counter shared across threads.
+//
+// TODOs:
+// 1) Implement `parallel_increment` so each thread increments the same counter.
+// 2) Return the final count.
+
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+pub fn parallel_increment(num_threads: usize, increments_per_thread: usize) -> usize {
+    let counter = Arc::new(Mutex::new(0usize));
+
+    let mut handles = Vec::new();
+    for _ in 0..num_threads {
+        let shared = Arc::clone(&counter);
+        handles.push(thread::spawn(move || {
+            for _ in 0..increments_per_thread {
+                let mut guard = shared.lock().expect("mutex poisoned");
+                *guard += 1;
+            }
+        }));
+    }
+
+    for handle in handles {
+        handle.join().expect("thread panicked");
+    }
+
+    *counter.lock().expect("mutex poisoned")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sums_all_increments() {
+        assert_eq!(parallel_increment(4, 10), 40);
+    }
+}

--- a/practical-rustlings/24_advanced_patterns/advanced_patterns2_rwlock_cache.rs
+++ b/practical-rustlings/24_advanced_patterns/advanced_patterns2_rwlock_cache.rs
@@ -1,0 +1,34 @@
+// Implement a tiny read-mostly cache with `RwLock`.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+#[derive(Default)]
+pub struct TinyCache {
+    inner: RwLock<HashMap<String, i64>>,
+}
+
+impl TinyCache {
+    pub fn insert(&self, key: &str, value: i64) {
+        let mut w = self.inner.write().expect("rwlock poisoned");
+        w.insert(key.to_string(), value);
+    }
+
+    pub fn get(&self, key: &str) -> Option<i64> {
+        let r = self.inner.read().expect("rwlock poisoned");
+        r.get(key).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_and_writes() {
+        let cache = TinyCache::default();
+        cache.insert("alpha", 7);
+        assert_eq!(cache.get("alpha"), Some(7));
+        assert_eq!(cache.get("beta"), None);
+    }
+}

--- a/practical-rustlings/24_advanced_patterns/advanced_patterns3_mpsc_fan_in.rs
+++ b/practical-rustlings/24_advanced_patterns/advanced_patterns3_mpsc_fan_in.rs
@@ -1,0 +1,36 @@
+// Combine values from multiple producer threads into one consumer.
+
+use std::sync::mpsc;
+use std::thread;
+
+pub fn fan_in_sum(chunks: Vec<Vec<i32>>) -> i32 {
+    let (tx, rx) = mpsc::channel();
+
+    let mut handles = Vec::new();
+    for chunk in chunks {
+        let producer = tx.clone();
+        handles.push(thread::spawn(move || {
+            for n in chunk {
+                producer.send(n).expect("receiver dropped");
+            }
+        }));
+    }
+    drop(tx);
+
+    for h in handles {
+        h.join().expect("thread panicked");
+    }
+
+    rx.iter().sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fan_in_works() {
+        let total = fan_in_sum(vec![vec![1, 2], vec![3], vec![4, 5]]);
+        assert_eq!(total, 15);
+    }
+}

--- a/practical-rustlings/24_advanced_patterns/advanced_patterns4_scoped_threads.rs
+++ b/practical-rustlings/24_advanced_patterns/advanced_patterns4_scoped_threads.rs
@@ -1,0 +1,24 @@
+// Use scoped threads to borrow slices without cloning.
+
+use std::thread;
+
+pub fn scoped_sum(values: &[i64]) -> i64 {
+    let mid = values.len() / 2;
+    let (left, right) = values.split_at(mid);
+
+    thread::scope(|scope| {
+        let left_handle = scope.spawn(move || left.iter().sum::<i64>());
+        let right_sum = right.iter().sum::<i64>();
+        left_handle.join().expect("scoped thread panicked") + right_sum
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sums_in_parallel() {
+        assert_eq!(scoped_sum(&[1, 2, 3, 4]), 10);
+    }
+}

--- a/practical-rustlings/24_advanced_patterns/advanced_patterns5_condvar_queue.rs
+++ b/practical-rustlings/24_advanced_patterns/advanced_patterns5_condvar_queue.rs
@@ -1,0 +1,42 @@
+// Implement a minimal one-item blocking queue using Mutex + Condvar.
+
+use std::sync::{Condvar, Mutex};
+
+#[derive(Default)]
+pub struct OneSlot<T> {
+    slot: Mutex<Option<T>>,
+    cv: Condvar,
+}
+
+impl<T> OneSlot<T> {
+    pub fn put(&self, value: T) {
+        let mut guard = self.slot.lock().expect("mutex poisoned");
+        while guard.is_some() {
+            guard = self.cv.wait(guard).expect("condvar wait failed");
+        }
+        *guard = Some(value);
+        self.cv.notify_one();
+    }
+
+    pub fn take(&self) -> T {
+        let mut guard = self.slot.lock().expect("mutex poisoned");
+        while guard.is_none() {
+            guard = self.cv.wait(guard).expect("condvar wait failed");
+        }
+        let value = guard.take().expect("slot must contain value");
+        self.cv.notify_one();
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn put_then_take() {
+        let q = OneSlot::default();
+        q.put(99);
+        assert_eq!(q.take(), 99);
+    }
+}

--- a/practical-rustlings/24_advanced_patterns/advanced_patterns6_pin_basics.rs
+++ b/practical-rustlings/24_advanced_patterns/advanced_patterns6_pin_basics.rs
@@ -1,0 +1,19 @@
+// Basic pinning drill: pin a vector and verify its backing pointer is stable.
+
+pub fn pin_and_address(values: Vec<u8>) -> (std::pin::Pin<Box<Vec<u8>>>, usize) {
+    let pinned = Box::pin(values);
+    let addr = pinned.as_ref().get_ref().as_ptr() as usize;
+    (pinned, addr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn address_stays_same_while_pinned() {
+        let (pinned, before) = pin_and_address(vec![1, 2, 3]);
+        let after = pinned.as_ref().get_ref().as_ptr() as usize;
+        assert_eq!(before, after);
+    }
+}

--- a/practical-rustlings/24_advanced_patterns/advanced_patterns7_retry_backoff.rs
+++ b/practical-rustlings/24_advanced_patterns/advanced_patterns7_retry_backoff.rs
@@ -1,0 +1,31 @@
+// Retry a fallible operation up to `attempts` times.
+
+pub fn retry_with_limit<T, E, F>(attempts: usize, mut op: F) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+{
+    assert!(attempts > 0, "attempts must be > 0");
+    let mut remaining = attempts;
+    loop {
+        match op() {
+            Ok(v) => return Ok(v),
+            Err(_) if remaining > 1 => remaining -= 1,
+            Err(e) => return Err(e),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retries_until_success() {
+        let mut n = 0;
+        let result = retry_with_limit(3, || {
+            n += 1;
+            if n < 3 { Err("not yet") } else { Ok(42) }
+        });
+        assert_eq!(result, Ok(42));
+    }
+}

--- a/practical-rustlings/24_advanced_patterns/advanced_patterns8_cow_normalize.rs
+++ b/practical-rustlings/24_advanced_patterns/advanced_patterns8_cow_normalize.rs
@@ -1,0 +1,28 @@
+// Return borrowed text when no normalization is needed, owned text otherwise.
+
+use std::borrow::Cow;
+
+pub fn normalize_spaces(input: &str) -> Cow<'_, str> {
+    if input.contains("  ") {
+        Cow::Owned(input.split_whitespace().collect::<Vec<_>>().join(" "))
+    } else {
+        Cow::Borrowed(input)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn avoids_alloc_when_possible() {
+        let x = normalize_spaces("a b c");
+        assert!(matches!(x, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn allocates_when_needed() {
+        let x = normalize_spaces("a  b   c");
+        assert_eq!(x, "a b c");
+    }
+}

--- a/practical-rustlings/24_advanced_patterns/advanced_patterns9_ffi_guard.rs
+++ b/practical-rustlings/24_advanced_patterns/advanced_patterns9_ffi_guard.rs
@@ -1,0 +1,26 @@
+// Wrap a nullable C string pointer into a safe Rust API.
+
+use std::ffi::CStr;
+use std::os::raw::c_char;
+
+pub fn c_string_len(ptr: *const c_char) -> Result<usize, &'static str> {
+    if ptr.is_null() {
+        return Err("null pointer");
+    }
+
+    let c_str = unsafe { CStr::from_ptr(ptr) };
+    c_str.to_str().map(|s| s.len()).map_err(|_| "invalid utf8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn handles_valid_and_null() {
+        let s = CString::new("chem").unwrap();
+        assert_eq!(c_string_len(s.as_ptr()), Ok(4));
+        assert_eq!(c_string_len(std::ptr::null()), Err("null pointer"));
+    }
+}

--- a/practical-rustlings/EXERCISES.md
+++ b/practical-rustlings/EXERCISES.md
@@ -1,4 +1,4 @@
-# Practical Rustlings Exercises (25)
+# Practical Rustlings Exercises (40)
 
 These exercises are grouped by the skill gaps identified in your assessment.
 
@@ -202,9 +202,113 @@ These exercises are grouped by the skill gaps identified in your assessment.
 
 ---
 
+## Track G — Advanced Rust Patterns (More Complex)
+
+### 26) `interior-mutability-bus`
+**Focus:** `Rc<RefCell<T>>` tradeoffs and runtime borrow safety.
+- Build a tiny event bus where handlers can enqueue follow-up events.
+- Explore how shared mutable state can deadlock at runtime borrow boundaries.
+
+**Done when:** tests demonstrate safe handler sequencing and avoid nested mutable borrows.
+
+### 27) `concurrent-pipeline`
+**Focus:** channels + worker coordination.
+- Build a 3-stage pipeline (`parse -> transform -> aggregate`) using threads and channels.
+- Ensure all sender handles are dropped so receivers terminate cleanly.
+
+**Done when:** no hangs, deterministic output ordering strategy is documented, and shutdown is explicit.
+
+### 28) `pin-and-self-reference`
+**Focus:** why pinning exists and when self-referential structs are dangerous.
+- Implement a safe API around pinned buffers or futures.
+- Add notes explaining what cannot be expressed safely without pinning.
+
+**Done when:** compile-time constraints prevent moves after pinning and tests verify address stability.
+
+### 29) `async-timeouts-retries`
+**Focus:** robust async orchestration.
+- Build an async operation with timeout + retry policy and backoff.
+- Classify retryable vs terminal errors.
+
+**Done when:** tests cover timeout, transient failure recovery, and terminal failure behavior.
+
+### 30) `ffi-boundary-safety`
+**Focus:** safe wrappers around `unsafe` boundary.
+- Create a tiny C-ABI style interface and a safe Rust wrapper.
+- Validate UTF-8 / null pointer / ownership transfer assumptions.
+
+**Done when:** all `unsafe` blocks are documented with invariants and wrapper API is panic-safe.
+
+---
+
+## Track H — Extra Advanced Folder Drills (`24_advanced_patterns`)
+
+### 31) `advanced_patterns1_arc_mutex`
+**Focus:** thread-safe shared mutation with `Arc<Mutex<T>>`.
+- Spawn multiple threads incrementing one shared counter.
+
+**Done when:** final count matches `threads * increments_per_thread`.
+
+### 32) `advanced_patterns2_rwlock_cache`
+**Focus:** read-heavy locking with `RwLock`.
+- Build a small cache API with read and write methods.
+
+**Done when:** repeated reads avoid write lock contention in design.
+
+### 33) `advanced_patterns3_mpsc_fan_in`
+**Focus:** producer fan-in over channels.
+- Send values from N producers into one consumer sum.
+
+**Done when:** all sender handles are dropped and receiver terminates naturally.
+
+### 34) `advanced_patterns4_scoped_threads`
+**Focus:** borrowing into threads with `std::thread::scope`.
+- Split a slice and compute partial sums concurrently.
+
+**Done when:** no cloning for borrowed halves and total is correct.
+
+### 35) `advanced_patterns5_condvar_queue`
+**Focus:** blocking synchronization primitives.
+- Implement put/take semantics for a one-slot queue.
+
+**Done when:** producer/consumer coordination works without busy-waiting.
+
+### 36) `advanced_patterns6_pin_basics`
+**Focus:** basic pinning semantics.
+- Pin a heap allocation and validate stable pointer identity.
+
+**Done when:** tests prove address stability while pinned.
+
+### 37) `advanced_patterns7_retry_backoff`
+**Focus:** robust retry loops.
+- Retry a fallible closure for a fixed attempt budget.
+
+**Done when:** success and final-error paths are both tested.
+
+### 38) `advanced_patterns8_cow_normalize`
+**Focus:** allocation-aware string APIs with `Cow<'_, str>`.
+- Borrow unchanged input, allocate only for normalized output.
+
+**Done when:** tests verify borrowed vs owned branches.
+
+### 39) `advanced_patterns9_ffi_guard`
+**Focus:** nullable pointer validation at FFI boundary.
+- Convert `*const c_char` into safe `&str`-backed behavior.
+
+**Done when:** null and invalid UTF-8 are handled as explicit errors.
+
+### 40) `advanced_patterns10_state_machine`
+**Focus:** compile-time state transitions.
+- Build `Initialized -> Running -> Finished` typed flow.
+
+**Done when:** impossible transitions are rejected by the type system.
+
+---
+
 ## Starter + reference code in this repo
 
-- `src/exercises.rs` provides starter APIs for every exercise number in this document.
+- `src/exercises.rs` provides starter APIs for exercises 1–30 in this document.
+- `24_advanced_patterns/` provides an additional 10 file-based drills (31–40).
 - `src/references.rs` provides compact, working references for selected exercises (transpose, typestate builder, units).
 
 You can either:

--- a/practical-rustlings/README.md
+++ b/practical-rustlings/README.md
@@ -25,3 +25,4 @@
 | macros                 | §20.5               |
 | clippy                 | Appendix D          |
 | conversions            | n/a                 |
+| advanced_patterns      | §15-17, §20         |

--- a/practical-rustlings/src/exercises.rs
+++ b/practical-rustlings/src/exercises.rs
@@ -1,4 +1,4 @@
-//! Starter surfaces for the 20 exercises listed in `EXERCISES.md`.
+//! Starter surfaces for the exercises listed in `EXERCISES.md`.
 //! Each function/type is intentionally minimal so you can evolve design yourself.
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -10,6 +10,9 @@ pub enum SimError {
     Overflow,
     MissingField,
     OutOfBounds,
+    BorrowConflict,
+    Timeout,
+    NullPtr,
 }
 
 // 1) ok-or-not-ok
@@ -255,10 +258,90 @@ pub fn batch_square(values: &[i64]) -> Vec<i64> {
     values.iter().map(|v| v * v).collect()
 }
 
+// 26) interior-mutability-bus
+pub fn push_event_safely(
+    queue: &std::rc::Rc<std::cell::RefCell<Vec<String>>>,
+    event: &str,
+) -> Result<(), SimError> {
+    let mut guard = queue.try_borrow_mut().map_err(|_| SimError::BorrowConflict)?;
+    guard.push(event.to_string());
+    Ok(())
+}
+
+// 27) concurrent-pipeline
+pub fn concurrent_square_sum(values: Vec<i64>) -> Result<i64, SimError> {
+    use std::sync::mpsc;
+    use std::thread;
+
+    let (tx_in, rx_in) = mpsc::channel::<i64>();
+    let (tx_out, rx_out) = mpsc::channel::<i64>();
+
+    let worker = thread::spawn(move || {
+        while let Ok(v) = rx_in.recv() {
+            if tx_out.send(v * v).is_err() {
+                break;
+            }
+        }
+    });
+
+    for value in values {
+        tx_in.send(value).map_err(|_| SimError::Parse)?;
+    }
+    drop(tx_in);
+
+    let mut total = 0_i64;
+    for squared in rx_out {
+        total += squared;
+    }
+
+    worker.join().map_err(|_| SimError::Parse)?;
+    Ok(total)
+}
+
+// 28) pin-and-self-reference
+pub fn pin_vec_and_get_addr(values: Vec<i32>) -> (std::pin::Pin<Box<Vec<i32>>>, usize) {
+    let pinned = Box::pin(values);
+    let addr = pinned.as_ref().get_ref().as_ptr() as usize;
+    (pinned, addr)
+}
+
+// 29) async-timeouts-retries
+pub fn retry_with_limit<T, E, F>(attempts: usize, mut operation: F) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+{
+    assert!(attempts > 0, "attempts must be > 0");
+    let mut remaining = attempts;
+    loop {
+        match operation() {
+            Ok(v) => return Ok(v),
+            Err(err) if remaining > 1 => {
+                remaining -= 1;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+// 30) ffi-boundary-safety
+pub fn c_string_len(ptr: *const std::os::raw::c_char) -> Result<usize, SimError> {
+    if ptr.is_null() {
+        return Err(SimError::NullPtr);
+    }
+    let c_str = unsafe { std::ffi::CStr::from_ptr(ptr) };
+    c_str
+        .to_str()
+        .map(|s| s.len())
+        .map_err(|_| SimError::Parse)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::RefCell;
     use std::collections::HashMap;
+    use std::ffi::CString;
+    use std::rc::Rc;
 
     #[test]
     fn normalizes_python_index() {
@@ -292,5 +375,53 @@ mod tests {
             required_positive_arg(&kwargs, "temperature_k"),
             Err(SimError::UnitMismatch)
         );
+    }
+
+    #[test]
+    fn interior_mutability_reports_borrow_conflict() {
+        let queue = Rc::new(RefCell::new(Vec::<String>::new()));
+        let _hold = queue.borrow_mut();
+        assert_eq!(
+            push_event_safely(&queue, "event-a"),
+            Err(SimError::BorrowConflict)
+        );
+    }
+
+    #[test]
+    fn concurrent_pipeline_squares_and_sums() {
+        assert_eq!(concurrent_square_sum(vec![1, 2, 3, 4]), Ok(30));
+        assert_eq!(concurrent_square_sum(vec![]), Ok(0));
+    }
+
+    #[test]
+    fn pinned_vector_address_is_stable() {
+        let (pinned, addr_before) = pin_vec_and_get_addr(vec![1, 2, 3]);
+        let addr_after = pinned.as_ref().get_ref().as_ptr() as usize;
+        assert_eq!(addr_before, addr_after);
+    }
+
+    #[test]
+    fn retries_until_success_or_exhaustion() {
+        let mut tries = 0usize;
+        let ok = retry_with_limit(3, || {
+            tries += 1;
+            if tries < 3 { Err(SimError::Timeout) } else { Ok(42) }
+        });
+        assert_eq!(ok, Ok(42));
+
+        let mut fails = 0usize;
+        let err: Result<i32, SimError> = retry_with_limit(2, || {
+            fails += 1;
+            Err(SimError::Timeout)
+        });
+        assert_eq!(err, Err(SimError::Timeout));
+        assert_eq!(fails, 2);
+    }
+
+    #[test]
+    fn c_string_boundary_checks() {
+        let msg = CString::new("rust").unwrap();
+        assert_eq!(c_string_len(msg.as_ptr()), Ok(4));
+        assert_eq!(c_string_len(std::ptr::null()), Err(SimError::NullPtr));
     }
 }


### PR DESCRIPTION
### Motivation

- Introduce a new set of 10 more complex exercises focused on advanced Rust patterns to provide deeper, file-based drills.
- Provide concrete, small reference implementations for concurrency, pinning, FFI, retry semantics, `Cow`, and a typed state machine to complement existing exercises. 
- Integrate the new exercises into the exercise index and the repository starter surface so tooling and docs reflect the expanded curriculum.

### Description

- Added a new folder `practical-rustlings/24_advanced_patterns/` containing 10 exercises with implementations and unit tests: `advanced_patterns1_arc_mutex.rs`, `advanced_patterns2_rwlock_cache.rs`, `advanced_patterns3_mpsc_fan_in.rs`, `advanced_patterns4_scoped_threads.rs`, `advanced_patterns5_condvar_queue.rs`, `advanced_patterns6_pin_basics.rs`, `advanced_patterns7_retry_backoff.rs`, `advanced_patterns8_cow_normalize.rs`, `advanced_patterns9_ffi_guard.rs`, and `advanced_patterns10_state_machine.rs`.
- Updated `practical-rustlings/EXERCISES.md` to add a new Track G and Track H entries and renumber the total exercises to include the 10 new drills, and updated `practical-rustlings/README.md` to reference the new `advanced_patterns` row.
- Extended `src/exercises.rs` by adding new `SimError` variants, and implementations for exercises 26–30 (interior mutability, concurrent pipeline, pin basics, retry helper, and FFI boundary helper) along with corresponding unit tests.
- Implementations exercise a variety of Rust primitives and patterns including `Arc<Mutex<_>>`, `RwLock`, `mpsc` channels, scoped threads, `Condvar` + `Mutex`, `Pin<Box<_>>`, `Cow<'_, str>`, `CStr` handling, and a typed-state machine typestate API.

### Testing

- Ran the repository unit tests with `cargo test` and all automated tests completed successfully.
- Executed the new unit tests in `practical-rustlings/24_advanced_patterns/*` which validate correctness for each added exercise and they passed.
- Ran the updated `src/exercises.rs` test suite verifying the new helper functions and error variants and those tests passed as well.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2a54463e4832e8a28d4885a4d5a92)