### PR TITLE
Add jaxlings rustlings-style JAX exercise track (25 exercises)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -15,6 +15,7 @@ This repository is now a **multi-language learning workspace** rather than a sin
 - `src/simulations/` — simulation-focused code
 - `src/data/` — data files used by scripts
 - `cxx/` — legacy C++ geometry code
+- `jaxlings/` — rustlings-style JAX exercises and solutions
 
 ## Build / run notes
 

--- a/jaxlings/EXERCISES.md
+++ b/jaxlings/EXERCISES.md
@@ -1,0 +1,29 @@
+# Exercise List (with solution mapping)
+
+| # | Track | Topic | Exercise File | Solution File |
+|---|---|---|---|---|
+| 00 | JAX | Create arrays, reshape, and stack with jax.numpy. | `exercises/00_jnp_arrays/array_basics.py` | `solutions/00_array_basics.py` |
+| 01 | JAX | Practice immutable updates with `.at[...]`. | `exercises/01_jnp_indexing/slicing_and_updates.py` | `solutions/01_slicing_and_updates.py` |
+| 02 | JAX | Use broadcasting for row/column transforms. | `exercises/02_broadcasting/broadcasting_ops.py` | `solutions/02_broadcasting_ops.py` |
+| 03 | JAX | Compute sums, means, and argmax reductions. | `exercises/03_reductions/reductions.py` | `solutions/03_reductions.py` |
+| 04 | JAX | Split PRNG keys and sample reproducibly. | `exercises/04_random/prng_keys.py` | `solutions/04_prng_keys.py` |
+| 05 | JAX | Vectorize a scalar function with `jax.vmap`. | `exercises/05_vmap/vmap_basics.py` | `solutions/05_vmap_basics.py` |
+| 06 | JAX | Differentiate a scalar-valued function with `jax.grad`. | `exercises/06_grad/grad_scalar.py` | `solutions/06_grad_scalar.py` |
+| 07 | JAX | Return loss and gradient together. | `exercises/07_value_and_grad/value_and_grad_loss.py` | `solutions/07_value_and_grad_loss.py` |
+| 08 | JAX | Wrap pure math with `jax.jit`. | `exercises/08_jit/jit_speed_stub.py` | `solutions/08_jit_speed_stub.py` |
+| 09 | JAX | Use `lax.cond` for branchy tensor logic. | `exercises/09_lax_control_flow/lax_cond_where.py` | `solutions/09_lax_cond_where.py` |
+| 10 | JAX | Build cumulative sums with `lax.scan`. | `exercises/10_lax_scan/scan_cumsum.py` | `solutions/10_scan_cumsum.py` |
+| 11 | JAX | Map over nested parameter pytrees. | `exercises/11_pytree/pytree_params.py` | `solutions/11_pytree_params.py` |
+| 12 | JAX | Implement a dense layer forward pass. | `exercises/12_nn_dense/dense_layer.py` | `solutions/12_dense_layer.py` |
+| 13 | JAX | Write one SGD update step. | `exercises/13_training_step/sgd_step.py` | `solutions/13_sgd_step.py` |
+| 14 | JAX | Build logistic predictions from logits. | `exercises/14_logistic_regression/logreg_predict.py` | `solutions/14_logreg_predict.py` |
+| 15 | JAX | Implement stable softmax cross-entropy. | `exercises/15_softmax_cross_entropy/cross_entropy.py` | `solutions/15_cross_entropy.py` |
+| 16 | JAX | Normalize a batch with epsilon stabilization. | `exercises/16_batchnorm_like/normalize_batch.py` | `solutions/16_normalize_batch.py` |
+| 17 | JAX | Apply 1D valid convolution with `lax.conv_general_dilated`. | `exercises/17_convolution/conv1d_valid.py` | `solutions/17_conv1d_valid.py` |
+| 18 | JAX | Compute Hessian diagonal via nested grads. | `exercises/18_autodiff_higher_order/hessian_diag.py` | `solutions/18_hessian_diag.py` |
+| 19 | JAX | Combine MSE and L2 regularization. | `exercises/19_custom_loss/regularized_mse.py` | `solutions/19_regularized_mse.py` |
+| 20 | JAX | Clip gradients to a max global norm. | `exercises/20_grad_clipping/clip_grad_norm.py` | `solutions/20_clip_grad_norm.py` |
+| 21 | JAX | Compute Jacobian of a vector function. | `exercises/21_jacobian/jacobian_linear.py` | `solutions/21_jacobian_linear.py` |
+| 22 | JAX | Read and complete a minimal `pmap` skeleton. | `exercises/22_pmap_reading/pmap_stub.py` | `solutions/22_pmap_stub.py` |
+| 23 | JAX | Save/load parameter pytree leaves via numpy. | `exercises/23_checkpointing/serialize_params.py` | `solutions/23_serialize_params.py` |
+| 24 | JAX | Compose a 2-layer MLP forward pass. | `exercises/24_capstone_mlp/mlp_forward.py` | `solutions/24_mlp_forward.py` |

--- a/jaxlings/README.md
+++ b/jaxlings/README.md
@@ -1,0 +1,27 @@
+# jaxlings
+
+A rustlings-style practice track for **JAX** fundamentals and model-building workflows.
+
+## How to use
+
+1. Open an exercise in `jaxlings/exercises/...`.
+2. Fill every `TODO` section.
+3. Run the file with Python.
+4. Compare with the matching answer in `jaxlings/solutions/...`.
+
+## Suggested flow
+
+- 00-04: `jax.numpy` arrays, reductions, and PRNG keys.
+- 05-10: transforms (`vmap`, `grad`, `jit`) and `lax` control flow.
+- 11-16: pytrees, dense layers, training basics, and losses.
+- 17-21: convolution and higher-order autodiff.
+- 22-24: device mapping, checkpointing, and MLP capstone.
+
+## Quick check commands
+
+```bash
+python jaxlings/check.py
+python -m compileall jaxlings/exercises jaxlings/solutions
+```
+
+> Install JAX first (CPU build): `pip install -U "jax[cpu]"`.

--- a/jaxlings/check.py
+++ b/jaxlings/check.py
@@ -1,0 +1,15 @@
+"""Tiny rustlings-like helper: list exercises and count TODOs."""
+from pathlib import Path
+
+
+def main() -> None:
+    root = Path(__file__).parent / "exercises"
+    files = sorted(root.glob("**/*.py"))
+    for file in files:
+        todo_count = file.read_text().count("TODO")
+        status = "✅" if todo_count == 0 else f"🧩 {todo_count} TODOs"
+        print(f"{file.relative_to(root)} -> {status}")
+
+
+if __name__ == "__main__":
+    main()

--- a/jaxlings/exercises/00_jnp_arrays/array_basics.py
+++ b/jaxlings/exercises/00_jnp_arrays/array_basics.py
@@ -1,0 +1,13 @@
+"""Exercise 00: Create arrays, reshape, and stack with jax.numpy."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/01_jnp_indexing/slicing_and_updates.py
+++ b/jaxlings/exercises/01_jnp_indexing/slicing_and_updates.py
@@ -1,0 +1,13 @@
+"""Exercise 01: Practice immutable updates with `.at[...]`."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/02_broadcasting/broadcasting_ops.py
+++ b/jaxlings/exercises/02_broadcasting/broadcasting_ops.py
@@ -1,0 +1,13 @@
+"""Exercise 02: Use broadcasting for row/column transforms."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/03_reductions/reductions.py
+++ b/jaxlings/exercises/03_reductions/reductions.py
@@ -1,0 +1,13 @@
+"""Exercise 03: Compute sums, means, and argmax reductions."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/04_random/prng_keys.py
+++ b/jaxlings/exercises/04_random/prng_keys.py
@@ -1,0 +1,13 @@
+"""Exercise 04: Split PRNG keys and sample reproducibly."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/05_vmap/vmap_basics.py
+++ b/jaxlings/exercises/05_vmap/vmap_basics.py
@@ -1,0 +1,13 @@
+"""Exercise 05: Vectorize a scalar function with `jax.vmap`."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/06_grad/grad_scalar.py
+++ b/jaxlings/exercises/06_grad/grad_scalar.py
@@ -1,0 +1,13 @@
+"""Exercise 06: Differentiate a scalar-valued function with `jax.grad`."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/07_value_and_grad/value_and_grad_loss.py
+++ b/jaxlings/exercises/07_value_and_grad/value_and_grad_loss.py
@@ -1,0 +1,13 @@
+"""Exercise 07: Return loss and gradient together."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/08_jit/jit_speed_stub.py
+++ b/jaxlings/exercises/08_jit/jit_speed_stub.py
@@ -1,0 +1,13 @@
+"""Exercise 08: Wrap pure math with `jax.jit`."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/09_lax_control_flow/lax_cond_where.py
+++ b/jaxlings/exercises/09_lax_control_flow/lax_cond_where.py
@@ -1,0 +1,13 @@
+"""Exercise 09: Use `lax.cond` for branchy tensor logic."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/10_lax_scan/scan_cumsum.py
+++ b/jaxlings/exercises/10_lax_scan/scan_cumsum.py
@@ -1,0 +1,13 @@
+"""Exercise 10: Build cumulative sums with `lax.scan`."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/11_pytree/pytree_params.py
+++ b/jaxlings/exercises/11_pytree/pytree_params.py
@@ -1,0 +1,13 @@
+"""Exercise 11: Map over nested parameter pytrees."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/12_nn_dense/dense_layer.py
+++ b/jaxlings/exercises/12_nn_dense/dense_layer.py
@@ -1,0 +1,13 @@
+"""Exercise 12: Implement a dense layer forward pass."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/13_training_step/sgd_step.py
+++ b/jaxlings/exercises/13_training_step/sgd_step.py
@@ -1,0 +1,13 @@
+"""Exercise 13: Write one SGD update step."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/14_logistic_regression/logreg_predict.py
+++ b/jaxlings/exercises/14_logistic_regression/logreg_predict.py
@@ -1,0 +1,13 @@
+"""Exercise 14: Build logistic predictions from logits."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/15_softmax_cross_entropy/cross_entropy.py
+++ b/jaxlings/exercises/15_softmax_cross_entropy/cross_entropy.py
@@ -1,0 +1,13 @@
+"""Exercise 15: Implement stable softmax cross-entropy."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/16_batchnorm_like/normalize_batch.py
+++ b/jaxlings/exercises/16_batchnorm_like/normalize_batch.py
@@ -1,0 +1,13 @@
+"""Exercise 16: Normalize a batch with epsilon stabilization."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/17_convolution/conv1d_valid.py
+++ b/jaxlings/exercises/17_convolution/conv1d_valid.py
@@ -1,0 +1,13 @@
+"""Exercise 17: Apply 1D valid convolution with `lax.conv_general_dilated`."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/18_autodiff_higher_order/hessian_diag.py
+++ b/jaxlings/exercises/18_autodiff_higher_order/hessian_diag.py
@@ -1,0 +1,13 @@
+"""Exercise 18: Compute Hessian diagonal via nested grads."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/19_custom_loss/regularized_mse.py
+++ b/jaxlings/exercises/19_custom_loss/regularized_mse.py
@@ -1,0 +1,13 @@
+"""Exercise 19: Combine MSE and L2 regularization."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/20_grad_clipping/clip_grad_norm.py
+++ b/jaxlings/exercises/20_grad_clipping/clip_grad_norm.py
@@ -1,0 +1,13 @@
+"""Exercise 20: Clip gradients to a max global norm."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/21_jacobian/jacobian_linear.py
+++ b/jaxlings/exercises/21_jacobian/jacobian_linear.py
@@ -1,0 +1,13 @@
+"""Exercise 21: Compute Jacobian of a vector function."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/22_pmap_reading/pmap_stub.py
+++ b/jaxlings/exercises/22_pmap_reading/pmap_stub.py
@@ -1,0 +1,13 @@
+"""Exercise 22: Read and complete a minimal `pmap` skeleton."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/23_checkpointing/serialize_params.py
+++ b/jaxlings/exercises/23_checkpointing/serialize_params.py
@@ -1,0 +1,13 @@
+"""Exercise 23: Save/load parameter pytree leaves via numpy."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/exercises/24_capstone_mlp/mlp_forward.py
+++ b/jaxlings/exercises/24_capstone_mlp/mlp_forward.py
@@ -1,0 +1,13 @@
+"""Exercise 24: Compose a 2-layer MLP forward pass."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    # TODO: implement this exercise.
+    # TODO: remove placeholder code once implemented.
+    raise NotImplementedError("Fill TODOs in this exercise")
+
+
+if __name__ == "__main__":
+    print("Run this file after completing TODOs:", __file__)

--- a/jaxlings/solutions/00_array_basics.py
+++ b/jaxlings/solutions/00_array_basics.py
@@ -1,0 +1,14 @@
+"""Solution 00: Create arrays, reshape, and stack with jax.numpy."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    a = jnp.arange(6).reshape(2, 3)
+    b = jnp.ones((2, 3))
+    c = jnp.stack([a, b], axis=0)
+    return a, b, c
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/01_slicing_and_updates.py
+++ b/jaxlings/solutions/01_slicing_and_updates.py
@@ -1,0 +1,14 @@
+"""Solution 01: Practice immutable updates with `.at[...]`."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    x = jnp.array([0., 1., 2., 3.])
+    y = x.at[1:3].set(jnp.array([10., 20.]))
+    z = y.at[0].add(5.)
+    return x, y, z
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/02_broadcasting_ops.py
+++ b/jaxlings/solutions/02_broadcasting_ops.py
@@ -1,0 +1,14 @@
+"""Solution 02: Use broadcasting for row/column transforms."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    x = jnp.arange(6.).reshape(2, 3)
+    row_bias = jnp.array([1., 2., 3.])
+    col_scale = jnp.array([[2.], [3.]])
+    return (x + row_bias) * col_scale
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/03_reductions.py
+++ b/jaxlings/solutions/03_reductions.py
@@ -1,0 +1,16 @@
+"""Solution 03: Compute sums, means, and argmax reductions."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    x = jnp.array([[1., 4., 2.], [7., 0., 5.]])
+    return {
+        "sum": jnp.sum(x),
+        "row_mean": jnp.mean(x, axis=1),
+        "argmax": jnp.argmax(x),
+    }
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/04_prng_keys.py
+++ b/jaxlings/solutions/04_prng_keys.py
@@ -1,0 +1,15 @@
+"""Solution 04: Split PRNG keys and sample reproducibly."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(seed: int = 0):
+    key = jax.random.PRNGKey(seed)
+    k1, k2 = jax.random.split(key)
+    a = jax.random.normal(k1, (3,))
+    b = jax.random.uniform(k2, (3,))
+    return a, b
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/05_vmap_basics.py
+++ b/jaxlings/solutions/05_vmap_basics.py
@@ -1,0 +1,13 @@
+"""Solution 05: Vectorize a scalar function with `jax.vmap`."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise():
+    f = lambda t: t * t + 1.0
+    batched = jax.vmap(f)
+    return batched(jnp.array([1., 2., 3.]))
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/06_grad_scalar.py
+++ b/jaxlings/solutions/06_grad_scalar.py
@@ -1,0 +1,13 @@
+"""Solution 06: Differentiate a scalar-valued function with `jax.grad`."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(x=2.0):
+    f = lambda t: t**3 + 2*t
+    g = jax.grad(f)
+    return g(x)
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/07_value_and_grad_loss.py
+++ b/jaxlings/solutions/07_value_and_grad_loss.py
@@ -1,0 +1,13 @@
+"""Solution 07: Return loss and gradient together."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(w=1.5):
+    loss = lambda t: (t - 3.0) ** 2
+    value, grad = jax.value_and_grad(loss)(w)
+    return value, grad
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/08_jit_speed_stub.py
+++ b/jaxlings/solutions/08_jit_speed_stub.py
@@ -1,0 +1,14 @@
+"""Solution 08: Wrap pure math with `jax.jit`."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(x):
+    @jax.jit
+    def f(t):
+        return jnp.sin(t) + t * t
+    return f(x)
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/09_lax_cond_where.py
+++ b/jaxlings/solutions/09_lax_cond_where.py
@@ -1,0 +1,17 @@
+"""Solution 09: Use `lax.cond` for branchy tensor logic."""
+import jax
+import jax.numpy as jnp
+
+from jax import lax
+
+def run_exercise(x):
+    return lax.cond(
+        jnp.mean(x) > 0,
+        lambda t: t * 2,
+        lambda t: -t,
+        x,
+    )
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/10_scan_cumsum.py
+++ b/jaxlings/solutions/10_scan_cumsum.py
@@ -1,0 +1,16 @@
+"""Solution 10: Build cumulative sums with `lax.scan`."""
+import jax
+import jax.numpy as jnp
+
+from jax import lax
+
+def run_exercise(x):
+    def step(carry, elem):
+        new_carry = carry + elem
+        return new_carry, new_carry
+    _, ys = lax.scan(step, 0.0, x)
+    return ys
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/11_pytree_params.py
+++ b/jaxlings/solutions/11_pytree_params.py
@@ -1,0 +1,11 @@
+"""Solution 11: Map over nested parameter pytrees."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(params):
+    return jax.tree_util.tree_map(lambda v: v * 0.5, params)
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/12_dense_layer.py
+++ b/jaxlings/solutions/12_dense_layer.py
@@ -1,0 +1,11 @@
+"""Solution 12: Implement a dense layer forward pass."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(x, w, b):
+    return x @ w + b
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/13_sgd_step.py
+++ b/jaxlings/solutions/13_sgd_step.py
@@ -1,0 +1,16 @@
+"""Solution 13: Write one SGD update step."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(w, x, y, lr=0.1):
+    def loss_fn(param):
+        pred = x * param
+        return jnp.mean((pred - y) ** 2)
+    loss, grad = jax.value_and_grad(loss_fn)(w)
+    new_w = w - lr * grad
+    return loss, new_w
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/14_logreg_predict.py
+++ b/jaxlings/solutions/14_logreg_predict.py
@@ -1,0 +1,12 @@
+"""Solution 14: Build logistic predictions from logits."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(x, w, b):
+    logits = x @ w + b
+    return jax.nn.sigmoid(logits)
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/15_cross_entropy.py
+++ b/jaxlings/solutions/15_cross_entropy.py
@@ -1,0 +1,12 @@
+"""Solution 15: Implement stable softmax cross-entropy."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(logits, labels):
+    log_probs = logits - jax.nn.logsumexp(logits, axis=-1, keepdims=True)
+    return -jnp.mean(jnp.sum(labels * log_probs, axis=-1))
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/16_normalize_batch.py
+++ b/jaxlings/solutions/16_normalize_batch.py
@@ -1,0 +1,13 @@
+"""Solution 16: Normalize a batch with epsilon stabilization."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(x, eps=1e-5):
+    mean = jnp.mean(x, axis=0, keepdims=True)
+    var = jnp.var(x, axis=0, keepdims=True)
+    return (x - mean) / jnp.sqrt(var + eps)
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/17_conv1d_valid.py
+++ b/jaxlings/solutions/17_conv1d_valid.py
@@ -1,0 +1,21 @@
+"""Solution 17: Apply 1D valid convolution with `lax.conv_general_dilated`."""
+import jax
+import jax.numpy as jnp
+
+from jax import lax
+
+def run_exercise(signal, kernel):
+    signal4 = signal[None, :, None]
+    kernel4 = kernel[:, None, None]
+    out = lax.conv_general_dilated(
+        signal4,
+        kernel4,
+        window_strides=(1,),
+        padding='VALID',
+        dimension_numbers=('NWC', 'WIO', 'NWC'),
+    )
+    return out[0, :, 0]
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/18_hessian_diag.py
+++ b/jaxlings/solutions/18_hessian_diag.py
@@ -1,0 +1,13 @@
+"""Solution 18: Compute Hessian diagonal via nested grads."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(x):
+    f = lambda t: jnp.sum(t**3)
+    hess = jax.jacfwd(jax.jacrev(f))(x)
+    return jnp.diag(hess)
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/19_regularized_mse.py
+++ b/jaxlings/solutions/19_regularized_mse.py
@@ -1,0 +1,13 @@
+"""Solution 19: Combine MSE and L2 regularization."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(pred, target, params, lam=1e-3):
+    mse = jnp.mean((pred - target) ** 2)
+    l2 = sum(jnp.sum(v * v) for v in jax.tree_util.tree_leaves(params))
+    return mse + lam * l2
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/20_clip_grad_norm.py
+++ b/jaxlings/solutions/20_clip_grad_norm.py
@@ -1,0 +1,14 @@
+"""Solution 20: Clip gradients to a max global norm."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(grads, max_norm=1.0):
+    leaves = jax.tree_util.tree_leaves(grads)
+    global_norm = jnp.sqrt(sum(jnp.sum(g * g) for g in leaves))
+    scale = jnp.minimum(1.0, max_norm / (global_norm + 1e-6))
+    return jax.tree_util.tree_map(lambda g: g * scale, grads), global_norm
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/21_jacobian_linear.py
+++ b/jaxlings/solutions/21_jacobian_linear.py
@@ -1,0 +1,12 @@
+"""Solution 21: Compute Jacobian of a vector function."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(x, w):
+    f = lambda t: w @ t
+    return jax.jacfwd(f)(x)
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/22_pmap_stub.py
+++ b/jaxlings/solutions/22_pmap_stub.py
@@ -1,0 +1,13 @@
+"""Solution 22: Read and complete a minimal `pmap` skeleton."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(x):
+    # This runs on one or many local devices.
+    mapped = jax.pmap(lambda t: t * 2)
+    return mapped(x)
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/23_serialize_params.py
+++ b/jaxlings/solutions/23_serialize_params.py
@@ -1,0 +1,18 @@
+"""Solution 23: Save/load parameter pytree leaves via numpy."""
+import jax
+import jax.numpy as jnp
+
+from pathlib import Path
+import numpy as np
+
+def run_exercise(params, out_file='jax_params.npz'):
+    leaves, treedef = jax.tree_util.tree_flatten(params)
+    arrays = {f'leaf_{i}': np.asarray(v) for i, v in enumerate(leaves)}
+    np.savez(out_file, **arrays)
+    loaded = np.load(out_file)
+    restored_leaves = [jnp.asarray(loaded[f'leaf_{i}']) for i in range(len(leaves))]
+    return jax.tree_util.tree_unflatten(treedef, restored_leaves)
+
+
+if __name__ == "__main__":
+    print(run_exercise)

--- a/jaxlings/solutions/24_mlp_forward.py
+++ b/jaxlings/solutions/24_mlp_forward.py
@@ -1,0 +1,13 @@
+"""Solution 24: Compose a 2-layer MLP forward pass."""
+import jax
+import jax.numpy as jnp
+
+
+def run_exercise(x, params):
+    w1, b1, w2, b2 = params
+    h = jax.nn.relu(x @ w1 + b1)
+    return h @ w2 + b2
+
+
+if __name__ == "__main__":
+    print(run_exercise)


### PR DESCRIPTION
### Motivation

- Provide a rustlings-style practice track for JAX to supplement the repository's existing learning tracks. 
- Cover core JAX workflows (arrays, indexing, broadcasting, PRNG, `vmap`/`grad`/`jit`, `lax`, pytrees, training/losses, higher-order autodiff, `pmap`, checkpointing, and an MLP capstone). 
- Keep exercises as TODO-driven stubs so learners can solve then compare against reference implementations. 

### Description

- Add a new `jaxlings/` track with `exercises/` (25 numbered exercises `00`–`24`) and one-to-one `solutions/` reference implementations. 
- Add `jaxlings/EXERCISES.md` mapping table and `jaxlings/README.md` with usage notes and quick-check commands. 
- Add `jaxlings/check.py` helper that scans exercises for `TODO` counts in a rustlings-like workflow. 
- Update top-level `README.txt` to list the new `jaxlings/` track. 

### Testing

- Ran `python jaxlings/check.py` which executed successfully and printed per-exercise TODO counts. 
- Ran `python -m compileall jaxlings/exercises jaxlings/solutions` which compiled the new modules without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c56abb5784832e9fa0996693b466f8)