### PR TITLE
Add Collections and Algorithmic Patterns tracks (exercises 41–60) with implementations and READMEs

### DIFF
--- a/practical-rustlings/25_collections_drills/README.md
+++ b/practical-rustlings/25_collections_drills/README.md
@@ -1,0 +1,7 @@
+# Collections Drills
+
+These exercises extend the main track with data-processing focused practice.
+
+- `collections1.rs`: moving averages over windows.
+- `collections2.rs`: chunked reductions with edge-case handling.
+- `collections3.rs`: deterministic word counting with `BTreeMap`.

--- a/practical-rustlings/25_collections_drills/collections1.rs
+++ b/practical-rustlings/25_collections_drills/collections1.rs
@@ -1,0 +1,14 @@
+fn moving_average_3(input: &[f64]) -> Vec<f64> {
+    if input.len() < 3 {
+        return Vec::new();
+    }
+    input
+        .windows(3)
+        .map(|w| (w[0] + w[1] + w[2]) / 3.0)
+        .collect()
+}
+
+fn main() {
+    let out = moving_average_3(&[1.0, 2.0, 3.0, 4.0]);
+    assert_eq!(out, vec![2.0, 3.0]);
+}

--- a/practical-rustlings/25_collections_drills/collections2.rs
+++ b/practical-rustlings/25_collections_drills/collections2.rs
@@ -1,0 +1,15 @@
+fn chunk_sum(values: &[i64], chunk_size: usize) -> Vec<i64> {
+    if chunk_size == 0 {
+        return Vec::new();
+    }
+
+    values
+        .chunks(chunk_size)
+        .map(|chunk| chunk.iter().sum())
+        .collect()
+}
+
+fn main() {
+    let out = chunk_sum(&[1, 2, 3, 4, 5], 2);
+    assert_eq!(out, vec![3, 7, 5]);
+}

--- a/practical-rustlings/25_collections_drills/collections3.rs
+++ b/practical-rustlings/25_collections_drills/collections3.rs
@@ -1,0 +1,15 @@
+use std::collections::BTreeMap;
+
+fn sorted_word_counts(words: &[&str]) -> BTreeMap<String, usize> {
+    let mut counts = BTreeMap::new();
+    for word in words {
+        *counts.entry((*word).to_owned()).or_insert(0) += 1;
+    }
+    counts
+}
+
+fn main() {
+    let counts = sorted_word_counts(&["beta", "alpha", "beta"]);
+    assert_eq!(counts.get("alpha"), Some(&1));
+    assert_eq!(counts.get("beta"), Some(&2));
+}

--- a/practical-rustlings/26_algorithmic_patterns/README.md
+++ b/practical-rustlings/26_algorithmic_patterns/README.md
@@ -1,0 +1,7 @@
+# Algorithmic Patterns
+
+These exercises focus on contract-heavy stdlib usage.
+
+- `algorithms1.rs`: insertion points via `binary_search`.
+- `algorithms2.rs`: overflow policy via saturating arithmetic.
+- `algorithms3.rs`: tiny arithmetic DSL parsing and evaluation.

--- a/practical-rustlings/26_algorithmic_patterns/algorithms1.rs
+++ b/practical-rustlings/26_algorithmic_patterns/algorithms1.rs
@@ -1,0 +1,10 @@
+fn lower_bound(sorted: &[i64], target: i64) -> usize {
+    match sorted.binary_search(&target) {
+        Ok(idx) | Err(idx) => idx,
+    }
+}
+
+fn main() {
+    assert_eq!(lower_bound(&[1, 3, 5], 4), 2);
+    assert_eq!(lower_bound(&[1, 3, 5], 5), 2);
+}

--- a/practical-rustlings/26_algorithmic_patterns/algorithms2.rs
+++ b/practical-rustlings/26_algorithmic_patterns/algorithms2.rs
@@ -1,0 +1,10 @@
+fn saturating_accumulate_u8(values: &[u8]) -> u8 {
+    values
+        .iter()
+        .copied()
+        .fold(0_u8, |acc, v| acc.saturating_add(v))
+}
+
+fn main() {
+    assert_eq!(saturating_accumulate_u8(&[250, 10]), u8::MAX);
+}

--- a/practical-rustlings/26_algorithmic_patterns/algorithms3.rs
+++ b/practical-rustlings/26_algorithmic_patterns/algorithms3.rs
@@ -1,0 +1,17 @@
+fn eval_add_mul(expr: &str) -> Option<i64> {
+    let mut acc = 0_i64;
+    for term in expr.split('+') {
+        let mut product = 1_i64;
+        for factor in term.split('*') {
+            let value = factor.trim().parse::<i64>().ok()?;
+            product = product.checked_mul(value)?;
+        }
+        acc = acc.checked_add(product)?;
+    }
+    Some(acc)
+}
+
+fn main() {
+    assert_eq!(eval_add_mul("2 * 3 + 4"), Some(10));
+    assert_eq!(eval_add_mul("x + 1"), None);
+}

--- a/practical-rustlings/EXERCISES.md
+++ b/practical-rustlings/EXERCISES.md
@@ -1,4 +1,4 @@
-# Practical Rustlings Exercises (40)
+# Practical Rustlings Exercises (60)
 
 These exercises are grouped by the skill gaps identified in your assessment.
 
@@ -305,9 +305,159 @@ These exercises are grouped by the skill gaps identified in your assessment.
 
 ---
 
+
+
+## Track I — Collections / Data Processing
+
+### 41) `const-generics-window`
+**Focus:** fixed-size windows and predictable aggregation.
+- Build moving-average helpers over contiguous windows.
+- Compare ergonomics of specialized (`N=3`) vs generic signatures.
+
+**Done when:** short and long slices are both handled cleanly.
+
+### 42) `phantom-type-phase`
+**Focus:** marker types to prevent phase/unit confusion.
+- Model at least two temperature phases with phantom types.
+- Permit only explicit conversion steps.
+
+**Done when:** mixed-phase usage fails at compile-time.
+
+### 43) `iterator-chunking`
+**Focus:** chunk-wise transformations with `chunks` and iterators.
+- Sum or reduce each chunk independently.
+- Define behavior when final chunk is shorter.
+
+**Done when:** edge cases (`chunk_size = 0`, uneven input) are tested.
+
+### 44) `serde-boundary-plan`
+**Focus:** parsing boundaries before domain logic.
+- Parse `key=value` records into typed domain fields.
+- Separate parse errors from semantic validation errors.
+
+**Done when:** parser helpers can be reused without pulling in business logic.
+
+### 45) `deterministic-rng-injection`
+**Focus:** testability through dependency injection.
+- Define a tiny RNG trait and inject it into domain code.
+- Use deterministic fake RNG in tests.
+
+**Done when:** behavior is reproducible and independent from global randomness.
+
+## Track J — Algorithmic Fluency / Stdlib Mastery
+
+### 46) `btreemap-vs-hashmap`
+**Focus:** choosing map semantics intentionally.
+- Implement counting with both `HashMap` and `BTreeMap`.
+- Compare deterministic ordering vs average-case speed.
+
+**Done when:** API docs explain the chosen map tradeoff.
+
+### 47) `saturating-vs-checked`
+**Focus:** overflow strategy as an API contract.
+- Implement one saturating and one checked accumulator.
+- Document where each behavior is appropriate.
+
+**Done when:** callers can clearly choose desired overflow policy.
+
+### 48) `slice-pattern-matching`
+**Focus:** expressive branching with slice patterns.
+- Classify fixed-length input patterns with guarded matches.
+- Keep fallback behavior explicit.
+
+**Done when:** pattern branches are exhaustive and readable.
+
+### 49) `binary-search-contract`
+**Focus:** lower-bound style APIs and sorted preconditions.
+- Wrap `binary_search` into a stable insertion-point helper.
+- Clarify behavior for hit and miss paths.
+
+**Done when:** contract is documented and unit-tested on duplicates.
+
+### 50) `small-dsl-evaluator`
+**Focus:** lightweight parsing + safe arithmetic.
+- Evaluate a tiny arithmetic DSL (for example `+` and `*`).
+- Use checked math to surface overflow errors.
+
+**Done when:** parser failures and overflow paths map to explicit error variants.
+
+
+
+## Track K — Production Rust Workflow Topics
+
+### 51) `trait-object-dispatch`
+**Focus:** dynamic dispatch and trait-object boundaries.
+- Pass behavior as `&dyn Trait` and evaluate call-site ergonomics.
+- Compare with generic dispatch for hot loops.
+
+**Done when:** tradeoffs are documented and both forms compile cleanly.
+
+### 52) `enum-driven-dispatch`
+**Focus:** explicit strategy selection via enums.
+- Model transform behavior with an enum and `match`.
+- Keep exhaustiveness checks working for future variants.
+
+**Done when:** adding a new strategy yields clear compiler guidance.
+
+### 53) `builder-default-overrides`
+**Focus:** safe defaults with explicit overrides.
+- Add a config type with useful defaults.
+- Validate user overrides before building runtime state.
+
+**Done when:** invalid overrides fail early with structured errors.
+
+### 54) `derive-more-manual-impl`
+**Focus:** mixing derives with hand-written trait impls.
+- Use `derive` where possible and implement remaining traits manually.
+- Explain correctness constraints for manual impls.
+
+**Done when:** semantics are clear and trait impl set is coherent.
+
+### 55) `parsing-state-machine`
+**Focus:** incremental parsing with stable contracts.
+- Parse a small structured string (`a:b`) with robust error handling.
+- Isolate parse helpers from domain logic.
+
+**Done when:** malformed inputs are rejected deterministically.
+
+### 56) `result-collect-partition`
+**Focus:** gathering successes while counting failures.
+- Partition parsed values into accepted/rejected groups.
+- Keep error accounting cheap and explicit.
+
+**Done when:** caller can inspect both output values and failure count.
+
+### 57) `lifetime-carrying-view`
+**Focus:** returning borrowed views without allocations.
+- Expose borrowed token slices tied to input lifetime.
+- Avoid unnecessary `String` allocations.
+
+**Done when:** API conveys borrowing constraints directly in signature.
+
+### 58) `path-dependent-errors`
+**Focus:** domain-specific error mapping.
+- Map distinct failure paths to distinct error variants.
+- Keep error branches easy to pattern-match by caller.
+
+**Done when:** each branch has a test and clear semantic meaning.
+
+### 59) `map-entry-api`
+**Focus:** `entry`-based in-place mutation.
+- Update counters atomically with `entry`.
+- Avoid extra lookups and temporary allocations.
+
+**Done when:** implementation uses one map lookup path.
+
+### 60) `mini-benchmark-harness`
+**Focus:** repeatable local performance probes.
+- Build a tiny repeat-run harness for closures.
+- Keep interface generic and zero-cost in release mode.
+
+**Done when:** harness is reusable across prior exercises.
+
 ## Starter + reference code in this repo
 
-- `src/exercises.rs` provides starter APIs for exercises 1–30 in this document.
+- `src/exercises.rs` provides starter APIs for exercises 1–30 and 41–60 in this document.
 - `24_advanced_patterns/` provides an additional 10 file-based drills (31–40).
 - `src/references.rs` provides compact, working references for selected exercises (transpose, typestate builder, units).
 

--- a/practical-rustlings/README.md
+++ b/practical-rustlings/README.md
@@ -26,3 +26,5 @@
 | clippy                 | Appendix D          |
 | conversions            | n/a                 |
 | advanced_patterns      | §15-17, §20         |
+| collections_drills      | n/a                 |
+| algorithmic_patterns    | n/a                 |

--- a/practical-rustlings/src/exercises.rs
+++ b/practical-rustlings/src/exercises.rs
@@ -425,3 +425,270 @@ mod tests {
         assert_eq!(c_string_len(std::ptr::null()), Err(SimError::NullPtr));
     }
 }
+
+// 26) interior-mutability-bus
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub type SharedQueue<T> = Rc<RefCell<Vec<T>>>;
+
+pub fn push_event<T>(queue: &SharedQueue<T>, event: T) {
+    queue.borrow_mut().push(event);
+}
+
+// 27) concurrent-pipeline
+pub fn parse_transform_aggregate(lines: &[&str]) -> Result<i64, SimError> {
+    lines
+        .iter()
+        .map(|line| line.trim().parse::<i64>().map_err(|_| SimError::Parse))
+        .map(|value| value.map(|v| v * 2))
+        .try_fold(0_i64, |acc, value| {
+            value.and_then(|v| acc.checked_add(v).ok_or(SimError::Overflow))
+        })
+}
+
+// 28) pin-and-self-reference
+pub fn pin_boxed_value<T>(value: T) -> std::pin::Pin<Box<T>> {
+    Box::pin(value)
+}
+
+// 29) async-timeouts-retries
+pub fn retry_with_budget<T, E, F>(attempts: usize, mut op: F) -> Result<T, E>
+where
+    F: FnMut() -> Result<T, E>,
+{
+    assert!(attempts > 0, "attempt budget must be > 0");
+    let mut last_error = None;
+    for _ in 0..attempts {
+        match op() {
+            Ok(value) => return Ok(value),
+            Err(err) => last_error = Some(err),
+        }
+    }
+    Err(last_error.expect("attempt budget guarantees at least one error"))
+}
+
+// 30) ffi-boundary-safety
+pub fn c_string_ptr_len(ptr: *const std::os::raw::c_char) -> Result<usize, SimError> {
+    if ptr.is_null() {
+        return Err(SimError::NullPtr);
+    }
+
+    // SAFETY: pointer nullness is checked above; CStr validates termination/UTF-8 below.
+    let cstr = unsafe { std::ffi::CStr::from_ptr(ptr) };
+    let text = cstr.to_str().map_err(|_| SimError::Parse)?;
+    Ok(text.len())
+}
+
+// 41) const-generics-window
+pub fn moving_average_3(input: &[f64]) -> Vec<f64> {
+    if input.len() < 3 {
+        return Vec::new();
+    }
+    input.windows(3).map(|w| (w[0] + w[1] + w[2]) / 3.0).collect()
+}
+
+// 42) phantom-type-phase
+pub struct Kelvin;
+pub struct Celsius;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Temperature<Unit> {
+    pub value: f64,
+    _unit: std::marker::PhantomData<Unit>,
+}
+
+pub fn celsius(v: f64) -> Temperature<Celsius> {
+    Temperature {
+        value: v,
+        _unit: std::marker::PhantomData,
+    }
+}
+
+pub fn to_kelvin(t: Temperature<Celsius>) -> Temperature<Kelvin> {
+    Temperature {
+        value: t.value + 273.15,
+        _unit: std::marker::PhantomData,
+    }
+}
+
+// 43) iterator-chunking
+pub fn chunk_sum(values: &[i64], chunk_size: usize) -> Vec<i64> {
+    if chunk_size == 0 {
+        return Vec::new();
+    }
+    values
+        .chunks(chunk_size)
+        .map(|chunk| chunk.iter().sum())
+        .collect()
+}
+
+// 44) serde-boundary-plan
+pub fn parse_key_value_line(line: &str) -> Result<(&str, &str), SimError> {
+    line.split_once('=').ok_or(SimError::Parse)
+}
+
+// 45) deterministic-rng-injection
+pub trait RngLike {
+    fn next_u32(&mut self) -> u32;
+}
+
+pub fn random_in_range(rng: &mut impl RngLike, upper_exclusive: u32) -> Result<u32, SimError> {
+    if upper_exclusive == 0 {
+        return Err(SimError::OutOfBounds);
+    }
+    Ok(rng.next_u32() % upper_exclusive)
+}
+
+// 46) btreemap-vs-hashmap
+pub fn sorted_word_counts(words: &[&str]) -> std::collections::BTreeMap<String, usize> {
+    let mut counts = std::collections::BTreeMap::new();
+    for word in words {
+        *counts.entry((*word).to_owned()).or_insert(0) += 1;
+    }
+    counts
+}
+
+// 47) saturating-vs-checked
+pub fn saturating_accumulate_u8(values: &[u8]) -> u8 {
+    values
+        .iter()
+        .copied()
+        .fold(0_u8, |acc, v| acc.saturating_add(v))
+}
+
+// 48) slice-pattern-matching
+pub fn classify_triplet(values: &[i32]) -> &'static str {
+    match values {
+        [a, b, c] if a <= b && b <= c => "nondecreasing",
+        [a, b, c] if a >= b && b >= c => "nonincreasing",
+        [_, _, _] => "mixed",
+        _ => "not-a-triplet",
+    }
+}
+
+// 49) binary-search-contract
+pub fn lower_bound(sorted: &[i64], target: i64) -> usize {
+    match sorted.binary_search(&target) {
+        Ok(idx) | Err(idx) => idx,
+    }
+}
+
+// 50) small-dsl-evaluator
+pub fn eval_add_mul(expr: &str) -> Result<i64, SimError> {
+    let mut acc = 0_i64;
+    for term in expr.split('+') {
+        let product = term
+            .split('*')
+            .map(|p| p.trim().parse::<i64>().map_err(|_| SimError::Parse))
+            .try_fold(1_i64, |acc, v| {
+                v.and_then(|n| acc.checked_mul(n).ok_or(SimError::Overflow))
+            })?;
+        acc = acc.checked_add(product).ok_or(SimError::Overflow)?;
+    }
+    Ok(acc)
+}
+
+
+// 51) trait-object-dispatch
+pub trait Metric {
+    fn score(&self, x: f64) -> f64;
+}
+
+pub fn sum_metric(metric: &dyn Metric, xs: &[f64]) -> f64 {
+    xs.iter().map(|&x| metric.score(x)).sum()
+}
+
+// 52) enum-driven-dispatch
+#[derive(Debug, Clone, Copy)]
+pub enum Transform {
+    Square,
+    Abs,
+    Negate,
+}
+
+pub fn apply_transform(t: Transform, x: f64) -> f64 {
+    match t {
+        Transform::Square => x * x,
+        Transform::Abs => x.abs(),
+        Transform::Negate => -x,
+    }
+}
+
+// 53) builder-default-overrides
+#[derive(Debug, Clone, Copy)]
+pub struct SolverConfig {
+    pub dt: f64,
+    pub steps: usize,
+}
+
+impl Default for SolverConfig {
+    fn default() -> Self {
+        Self { dt: 0.01, steps: 100 }
+    }
+}
+
+pub fn config_with_steps(steps: usize) -> Result<SolverConfig, SimError> {
+    if steps == 0 {
+        return Err(SimError::OutOfBounds);
+    }
+    Ok(SolverConfig { steps, ..SolverConfig::default() })
+}
+
+// 54) derive-more-manual-impl
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParticleState {
+    pub id: usize,
+    pub energy: f64,
+}
+
+impl Eq for ParticleState {}
+
+// 55) parsing-state-machine
+pub fn parse_pair(line: &str) -> Result<(i64, i64), SimError> {
+    let (a, b) = line.split_once(':').ok_or(SimError::Parse)?;
+    let x = a.trim().parse::<i64>().map_err(|_| SimError::Parse)?;
+    let y = b.trim().parse::<i64>().map_err(|_| SimError::Parse)?;
+    Ok((x, y))
+}
+
+// 56) result-collect-partition
+pub fn collect_ok_values(values: &[&str]) -> (Vec<i64>, usize) {
+    let mut oks = Vec::new();
+    let mut errs = 0usize;
+    for v in values {
+        match v.parse::<i64>() {
+            Ok(n) => oks.push(n),
+            Err(_) => errs += 1,
+        }
+    }
+    (oks, errs)
+}
+
+// 57) lifetime-carrying-view
+pub fn first_token<'a>(line: &'a str) -> Option<&'a str> {
+    line.split_whitespace().next()
+}
+
+// 58) path-dependent-errors
+pub fn ratio(numerator: f64, denominator: f64) -> Result<f64, SimError> {
+    if denominator == 0.0 {
+        return Err(SimError::NonConvergent);
+    }
+    Ok(numerator / denominator)
+}
+
+// 59) map-entry-api
+pub fn increment_counter(map: &mut std::collections::HashMap<String, usize>, key: &str) {
+    *map.entry(key.to_string()).or_insert(0) += 1;
+}
+
+// 60) mini-benchmark-harness
+pub fn run_n_times<F>(n: usize, mut f: F)
+where
+    F: FnMut(),
+{
+    for _ in 0..n {
+        f();
+    }
+}


### PR DESCRIPTION
### Motivation
- Expand the exercise set with two new tracks focused on collections/data-processing and algorithmic/stdlib patterns to increase coverage from 40 to 60 exercises. 
- Provide compact reference implementations and per-track README entries to guide learners and to serve as starter code.

### Description
- Add `25_collections_drills/` and `26_algorithmic_patterns/` directories with per-exercise example files and track READMEs demonstrating `moving_average_3`, `chunk_sum`, `sorted_word_counts`, `lower_bound`, `saturating_accumulate_u8`, `eval_add_mul`, and related drills. 
- Update `EXERCISES.md` to include Tracks I and J (exercises 41–60) and bump the exercise count to 60, including short descriptions and done-conditions for each new exercise. 
- Update `practical-rustlings/README.md` to list the new track names in the overview table. 
- Add implementations for exercises 41–60 into `src/exercises.rs`, including utilities and APIs such as `moving_average_3`, `chunk_sum`, `sorted_word_counts`, `lower_bound`, `eval_add_mul` (checked arithmetic), `saturating_accumulate_u8`, `SharedQueue` helpers, parsing helpers, a tiny RNG trait, metric/transform examples, config builder, parsing helpers, partition/collection helpers, and a mini benchmark harness.

### Testing
- Ran the crate unit tests with `cargo test`, and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c570d47c8c832eab20cca463cd4aa7)