### PR TITLE
Add `?` operator mastery exercises (Track L) to practical-rustlings

### DIFF
--- a/practical-rustlings/EXERCISES.md
+++ b/practical-rustlings/EXERCISES.md
@@ -1,4 +1,4 @@
-# Practical Rustlings Exercises (60)
+# Practical Rustlings Exercises (65)
 
 These exercises are grouped by the skill gaps identified in your assessment.
 
@@ -455,9 +455,46 @@ These exercises are grouped by the skill gaps identified in your assessment.
 
 **Done when:** harness is reusable across prior exercises.
 
+## Track L — `?` Operator Mastery
+
+### 61) `question-mark-boundary`
+**Focus:** understanding where `?` is legal.
+- Write one function that fails to compile with `?` in a `fn -> i32`.
+- Refactor it into `fn -> Result<i32, E>` and explain the change.
+
+**Done when:** you can explain, in your own words, why return type compatibility is required.
+
+### 62) `option-to-result-bridge`
+**Focus:** using `ok_or`/`ok_or_else` before `?`.
+- Parse config from a map where keys are optional.
+- Convert missing values (`Option`) into domain errors (`Result`) and propagate with `?`.
+
+**Done when:** missing key and parse failures produce distinct error variants.
+
+### 63) `result-to-option-bridge`
+**Focus:** using `?` with `Option`.
+- Implement a function returning `Option<T>` that calls helpers returning `Option`.
+- Compare with an equivalent `Result` version and note tradeoffs.
+
+**Done when:** both versions pass tests and the loss of error detail is explicit.
+
+### 64) `error-conversion-with-from`
+**Focus:** implicit conversion during `?` propagation.
+- Define two error enums and implement `From<InnerErr> for OuterErr`.
+- Use `?` across helper calls without manual `map_err`.
+
+**Done when:** conversion happens automatically and tests cover multiple failure sources.
+
+### 65) `main-return-result`
+**Focus:** using `?` in executable entry points.
+- Change a small CLI-style `main` from panicking calls to `main() -> Result<(), E>`.
+- Propagate parse + I/O style errors with `?`.
+
+**Done when:** no `unwrap`/`expect` is needed in the happy path and error output remains useful.
+
 ## Starter + reference code in this repo
 
-- `src/exercises.rs` provides starter APIs for exercises 1–30 and 41–60 in this document.
+- `src/exercises.rs` provides starter APIs for exercises 1–30 and 41–65 in this document.
 - `24_advanced_patterns/` provides an additional 10 file-based drills (31–40).
 - `src/references.rs` provides compact, working references for selected exercises (transpose, typestate builder, units).
 

--- a/practical-rustlings/src/exercises.rs
+++ b/practical-rustlings/src/exercises.rs
@@ -692,3 +692,68 @@ where
         f();
     }
 }
+
+// 61) question-mark-boundary
+pub fn parse_and_double_result(input: &str) -> Result<i64, SimError> {
+    let n = input.trim().parse::<i64>().map_err(|_| SimError::Parse)?;
+    Ok(n * 2)
+}
+
+// 62) option-to-result-bridge
+pub fn read_required_i64(
+    values: &std::collections::HashMap<String, String>,
+    key: &str,
+) -> Result<i64, SimError> {
+    let raw = values.get(key).ok_or(SimError::MissingField)?;
+    let parsed = raw.parse::<i64>().map_err(|_| SimError::Parse)?;
+    Ok(parsed)
+}
+
+// 63) result-to-option-bridge
+pub fn parse_pair_option(input: &str) -> Option<(i64, i64)> {
+    let (lhs, rhs) = input.split_once(':')?;
+    let a = lhs.trim().parse::<i64>().ok()?;
+    let b = rhs.trim().parse::<i64>().ok()?;
+    Some((a, b))
+}
+
+// 64) error-conversion-with-from
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParserError {
+    Empty,
+    Parse,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PipelineError {
+    BadInput(ParserError),
+    Overflow,
+}
+
+impl From<ParserError> for PipelineError {
+    fn from(value: ParserError) -> Self {
+        Self::BadInput(value)
+    }
+}
+
+pub fn parse_nonempty_i64(input: &str) -> Result<i64, ParserError> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(ParserError::Empty);
+    }
+    trimmed.parse::<i64>().map_err(|_| ParserError::Parse)
+}
+
+pub fn parse_and_square_pipeline(input: &str) -> Result<i64, PipelineError> {
+    let n = parse_nonempty_i64(input)?;
+    n.checked_mul(n).ok_or(PipelineError::Overflow)
+}
+
+// 65) main-return-result
+pub fn cli_sum(args: &[String]) -> Result<i64, SimError> {
+    let first = args.first().ok_or(SimError::MissingField)?;
+    let second = args.get(1).ok_or(SimError::MissingField)?;
+    let a = first.parse::<i64>().map_err(|_| SimError::Parse)?;
+    let b = second.parse::<i64>().map_err(|_| SimError::Parse)?;
+    a.checked_add(b).ok_or(SimError::Overflow)
+}


### PR DESCRIPTION
### Motivation
- Teach and exercise the Rust `?` operator rule that it may only be used in functions returning a `Result`, `Option`, or another `Try`-compatible type by adding focused drills.
- Provide practical starter code that demonstrates common `?`-related patterns like `Option`→`Result` bridging, `From`-based error conversion, and `main` returning `Result`.

### Description
- Added a new "Track L — `?` Operator Mastery" section to `practical-rustlings/EXERCISES.md` expanding the catalog from 60 to 65 exercises and documenting exercises 61–65. 
- Implemented starter APIs for exercises 61–65 in `practical-rustlings/src/exercises.rs`, including `parse_and_double_result`, `read_required_i64`, `parse_pair_option`, `parse_nonempty_i64`/`parse_and_square_pipeline` with `From`-based conversion, and `cli_sum`.
- Introduced `ParserError` and `PipelineError` enums and an `impl From<ParserError> for PipelineError` to demonstrate implicit error conversion with `?`.
- Updated the starter-code note in `EXERCISES.md` to reference exercises through 65.

### Testing
- Ran `cargo test` in `practical-rustlings/` and the test suite built successfully and executed the unit tests. 
- All automated tests passed: `11 passed; 0 failed` (unit tests and doc-tests completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c6b6c3bf54832ebd4f617a84f8cb94)