### PR TITLE
Add Track M (Quant Rust Drills) with starter exercises and APIs

### DIFF
--- a/practical-rustlings/EXERCISES.md
+++ b/practical-rustlings/EXERCISES.md
@@ -1,4 +1,4 @@
-# Practical Rustlings Exercises (65)
+# Practical Rustlings Exercises (73)
 
 These exercises are grouped by the skill gaps identified in your assessment.
 
@@ -492,9 +492,67 @@ These exercises are grouped by the skill gaps identified in your assessment.
 
 **Done when:** no `unwrap`/`expect` is needed in the happy path and error output remains useful.
 
+## Track M — Quant Rust Drills
+
+### 66) `returns-simple-vs-log`
+**Focus:** return conventions in quant pipelines.
+- Implement both simple returns and log returns.
+- Compare aggregation behavior and edge cases near zero prices.
+
+**Done when:** tests show expected return values and invalid price inputs are rejected.
+
+### 67) `rolling-volatility`
+**Focus:** fixed-window risk calculations.
+- Compute rolling sample volatility over a window length `n`.
+- Return an output aligned to the final index of each full window.
+
+**Done when:** output length and numeric values match hand-checked examples.
+
+### 68) `drawdown-tracker`
+**Focus:** path-dependent risk metrics.
+- Implement max drawdown calculation from an equity curve.
+- Track running peak and percentage drop from peak.
+
+**Done when:** monotonic-up and deep-drop paths are both covered by tests.
+
+### 69) `position-sizer`
+**Focus:** translating risk budget into shares/contracts.
+- Given equity, risk fraction, stop distance, and point value, compute position size.
+- Decide rounding policy explicitly (`floor`, `round`, etc.).
+
+**Done when:** invalid inputs are surfaced and sizing policy is documented.
+
+### 70) `pnl-attribution`
+**Focus:** decomposition and sign correctness.
+- Decompose PnL into `price_move * quantity * multiplier`.
+- Handle long/short sign conventions clearly.
+
+**Done when:** tests include long gain, short gain, and flat/no-change scenarios.
+
+### 71) `order-book-spread`
+**Focus:** market microstructure basics.
+- Validate top-of-book quotes (`best_bid <= best_ask`).
+- Compute spread in ticks and basis points.
+
+**Done when:** crossed/locked books are handled according to your API contract.
+
+### 72) `ewma-risk-model`
+**Focus:** stateful time-series estimation.
+- Implement an EWMA variance update (`lambda` decay).
+- Expose both one-step update and full-series helper.
+
+**Done when:** lambda boundary behavior is tested and numerically stable.
+
+### 73) `black-scholes-baseline`
+**Focus:** numerical finance with clear assumptions.
+- Implement call/put Black–Scholes pricing for non-dividend assets.
+- Keep units explicit (`time in years`, `vol annualized`).
+
+**Done when:** put-call parity holds approximately and obvious bad inputs return structured errors.
+
 ## Starter + reference code in this repo
 
-- `src/exercises.rs` provides starter APIs for exercises 1–30 and 41–65 in this document.
+- `src/exercises.rs` provides starter APIs for exercises 1–30 and 41–73 in this document.
 - `24_advanced_patterns/` provides an additional 10 file-based drills (31–40).
 - `src/references.rs` provides compact, working references for selected exercises (transpose, typestate builder, units).
 

--- a/practical-rustlings/README.md
+++ b/practical-rustlings/README.md
@@ -28,3 +28,4 @@
 | advanced_patterns      | §15-17, §20         |
 | collections_drills      | n/a                 |
 | algorithmic_patterns    | n/a                 |
+| quant_rust_drills       | n/a                 |

--- a/practical-rustlings/src/exercises.rs
+++ b/practical-rustlings/src/exercises.rs
@@ -219,6 +219,185 @@ pub fn pyo3_scale(values: &[f64], scale: Option<f64>) -> Vec<f64> {
     values.iter().map(|v| v * factor).collect()
 }
 
+// 66) returns-simple-vs-log
+pub fn simple_return(prev: f64, next: f64) -> Result<f64, SimError> {
+    if prev <= 0.0 || next <= 0.0 {
+        return Err(SimError::OutOfBounds);
+    }
+    Ok(next / prev - 1.0)
+}
+
+pub fn log_return(prev: f64, next: f64) -> Result<f64, SimError> {
+    if prev <= 0.0 || next <= 0.0 {
+        return Err(SimError::OutOfBounds);
+    }
+    Ok((next / prev).ln())
+}
+
+// 67) rolling-volatility
+pub fn rolling_sample_volatility(returns: &[f64], window: usize) -> Result<Vec<f64>, SimError> {
+    if window < 2 || window > returns.len() {
+        return Err(SimError::OutOfBounds);
+    }
+
+    let mut out = Vec::with_capacity(returns.len() - window + 1);
+    for chunk in returns.windows(window) {
+        let mean = chunk.iter().sum::<f64>() / window as f64;
+        let var = chunk
+            .iter()
+            .map(|x| {
+                let d = x - mean;
+                d * d
+            })
+            .sum::<f64>()
+            / (window as f64 - 1.0);
+        out.push(var.sqrt());
+    }
+    Ok(out)
+}
+
+// 68) drawdown-tracker
+pub fn max_drawdown(equity_curve: &[f64]) -> Result<f64, SimError> {
+    if equity_curve.is_empty() {
+        return Err(SimError::MissingField);
+    }
+    if equity_curve.iter().any(|x| *x <= 0.0) {
+        return Err(SimError::OutOfBounds);
+    }
+
+    let mut peak = equity_curve[0];
+    let mut worst = 0.0f64;
+    for &value in equity_curve {
+        if value > peak {
+            peak = value;
+        }
+        let dd = (peak - value) / peak;
+        if dd > worst {
+            worst = dd;
+        }
+    }
+    Ok(worst)
+}
+
+// 69) position-sizer
+pub fn position_size(
+    equity: f64,
+    risk_fraction: f64,
+    stop_distance: f64,
+    point_value: f64,
+) -> Result<u64, SimError> {
+    if equity <= 0.0 || stop_distance <= 0.0 || point_value <= 0.0 {
+        return Err(SimError::OutOfBounds);
+    }
+    if !(0.0..=1.0).contains(&risk_fraction) {
+        return Err(SimError::OutOfBounds);
+    }
+
+    let risk_budget = equity * risk_fraction;
+    let units = (risk_budget / (stop_distance * point_value)).floor();
+    if !units.is_finite() || units < 0.0 {
+        return Err(SimError::Overflow);
+    }
+    Ok(units as u64)
+}
+
+// 70) pnl-attribution
+pub fn pnl(price_entry: f64, price_exit: f64, quantity: f64, multiplier: f64) -> f64 {
+    (price_exit - price_entry) * quantity * multiplier
+}
+
+// 71) order-book-spread
+pub fn spread_ticks(best_bid: f64, best_ask: f64, tick_size: f64) -> Result<f64, SimError> {
+    if tick_size <= 0.0 || best_bid <= 0.0 || best_ask <= 0.0 {
+        return Err(SimError::OutOfBounds);
+    }
+    if best_bid > best_ask {
+        return Err(SimError::InvalidTransition);
+    }
+    Ok((best_ask - best_bid) / tick_size)
+}
+
+pub fn spread_bps(best_bid: f64, best_ask: f64) -> Result<f64, SimError> {
+    if best_bid <= 0.0 || best_ask <= 0.0 {
+        return Err(SimError::OutOfBounds);
+    }
+    if best_bid > best_ask {
+        return Err(SimError::InvalidTransition);
+    }
+    let mid = 0.5 * (best_bid + best_ask);
+    Ok((best_ask - best_bid) / mid * 10_000.0)
+}
+
+// 72) ewma-risk-model
+pub fn ewma_variance_step(prev_variance: f64, return_t: f64, lambda: f64) -> Result<f64, SimError> {
+    if prev_variance < 0.0 || !(0.0..1.0).contains(&lambda) {
+        return Err(SimError::OutOfBounds);
+    }
+    Ok(lambda * prev_variance + (1.0 - lambda) * return_t * return_t)
+}
+
+pub fn ewma_variance_series(returns: &[f64], lambda: f64, seed_variance: f64) -> Result<Vec<f64>, SimError> {
+    if returns.is_empty() {
+        return Err(SimError::MissingField);
+    }
+    let mut out = Vec::with_capacity(returns.len());
+    let mut var = seed_variance;
+    for &r in returns {
+        var = ewma_variance_step(var, r, lambda)?;
+        out.push(var);
+    }
+    Ok(out)
+}
+
+// 73) black-scholes-baseline
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum OptionKind {
+    Call,
+    Put,
+}
+
+pub fn black_scholes_price(
+    kind: OptionKind,
+    spot: f64,
+    strike: f64,
+    rate: f64,
+    vol: f64,
+    time_years: f64,
+) -> Result<f64, SimError> {
+    if spot <= 0.0 || strike <= 0.0 || vol <= 0.0 || time_years <= 0.0 {
+        return Err(SimError::OutOfBounds);
+    }
+
+    let sqrt_t = time_years.sqrt();
+    let d1 = ((spot / strike).ln() + (rate + 0.5 * vol * vol) * time_years) / (vol * sqrt_t);
+    let d2 = d1 - vol * sqrt_t;
+    let nd1 = standard_normal_cdf(d1);
+    let nd2 = standard_normal_cdf(d2);
+    let discount = (-rate * time_years).exp();
+
+    let price = match kind {
+        OptionKind::Call => spot * nd1 - strike * discount * nd2,
+        OptionKind::Put => strike * discount * standard_normal_cdf(-d2) - spot * standard_normal_cdf(-d1),
+    };
+    Ok(price)
+}
+
+fn standard_normal_cdf(x: f64) -> f64 {
+    0.5 * (1.0 + erf_approx(x / std::f64::consts::SQRT_2))
+}
+
+fn erf_approx(x: f64) -> f64 {
+    let sign = x.signum();
+    let ax = x.abs();
+    let t = 1.0 / (1.0 + 0.3275911 * ax);
+    let y = 1.0
+        - (((((1.061405429 * t - 1.453152027) * t) + 1.421413741) * t - 0.284496736) * t
+            + 0.254829592)
+            * t
+            * (-ax * ax).exp();
+    sign * y
+}
+
 // 22) python-index-semantics
 pub fn normalize_py_index(len: usize, index: isize) -> Result<usize, SimError> {
     if len == 0 {


### PR DESCRIPTION
### Motivation
- Provide a focused set of beginner-to-intermediate quant engineering drills so learners can practice finance/risk primitives in Rust.
- Keep the new exercises consistent with the existing Rustlings-style starter surfaces and small, testable helpers.

### Description
- Added a new "Track M — Quant Rust Drills" section to `practical-rustlings/EXERCISES.md` and updated the total count from `65` to `73` to include exercises `66`–`73`.
- Updated the chapter mapping table in `practical-rustlings/README.md` to include `quant_rust_drills`.
- Implemented starter APIs in `practical-rustlings/src/exercises.rs` for quant drills including `simple_return`, `log_return`, `rolling_sample_volatility`, `max_drawdown`, `position_size`, `pnl`, `spread_ticks`, `spread_bps`, `ewma_variance_step`, `ewma_variance_series`, and `black_scholes_price` plus the `OptionKind` enum and helper functions `standard_normal_cdf` and `erf_approx`.
- Kept implementations intentionally lightweight to act as starter surfaces for learning, refactoring, and test-driven exercises.

### Testing
- Ran `cargo test` in `practical-rustlings/` and all unit tests completed successfully: 11 tests passed, 0 failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca9bf917c8832e8523ee68a0e1232d)