### PR TITLE
Expand pytorchlings with advanced PyTorch training track (exercises 38–47)

### DIFF
--- a/pytorchlings/EXERCISES.md
+++ b/pytorchlings/EXERCISES.md
@@ -40,3 +40,15 @@
 | 35 | PyG | GraphGym config basics | `exercises/35_graphgym_config/graphgym_config.py` | `solutions/35_graphgym_config.py` |
 | 36 | PyG | GraphGym custom pooling registration | `exercises/36_graphgym_register/register_pooling.py` | `solutions/36_register_pooling.py` |
 | 37 | PyG | GraphGym YAML experiment setup | `exercises/37_graphgym_yaml/build_experiment_yaml.py` | `solutions/37_graphgym_yaml.py` |
+
+| 38 | PyTorch | Loss functions from logits | `exercises/38_losses_and_logits/losses_and_logits.py` | `solutions/38_losses_and_logits.py` |
+| 39 | PyTorch | Device + dtype alignment | `exercises/39_device_dtype/device_and_dtype.py` | `solutions/39_device_dtype.py` |
+| 40 | PyTorch | Eval mode + `torch.no_grad()` | `exercises/40_no_grad_inference/no_grad_eval.py` | `solutions/40_no_grad_eval.py` |
+| 41 | PyTorch | Forward hooks for activations | `exercises/41_hooks_and_features/forward_hook_capture.py` | `solutions/41_forward_hook_capture.py` |
+| 42 | PyTorch | Kaiming init + bias zeroing | `exercises/42_initialization/weight_init_strategies.py` | `solutions/42_weight_init_strategies.py` |
+| 43 | PyTorch | Gradient accumulation training loop | `exercises/43_gradient_accumulation/gradient_accumulation.py` | `solutions/43_gradient_accumulation.py` |
+| 44 | PyTorch | AMP with autocast + GradScaler | `exercises/44_amp_basics/amp_training_step.py` | `solutions/44_amp_training_step.py` |
+| 45 | PyTorch | `torch.compile` smoke workflow | `exercises/45_torch_compile/compile_smoke.py` | `solutions/45_compile_smoke.py` |
+| 46 | PyTorch | TorchScript export (`script`/`trace`) | `exercises/46_torchscript_export/torchscript_trace_script.py` | `solutions/46_torchscript_trace_script.py` |
+| 47 | PyTorch | Packed sequences for variable-length RNNs | `exercises/47_packed_sequences/packed_sequence_rnn.py` | `solutions/47_packed_sequence_rnn.py` |
+

--- a/pytorchlings/README.md
+++ b/pytorchlings/README.md
@@ -19,6 +19,7 @@ A rustlings-style practice track for **PyTorch** and **PyTorch Geometric (PyG)**
 - Finish with 28-30 for NetworkX `nx.Graph` practice.
 - Continue 31-34 for weighted, directed, bipartite, and cycle/tree graph workflows.
 - Add 35-37 for PyG GraphGym config, registration, and experiment YAML practice.
+- Complete 38-47 for comprehensive PyTorch engineering workflows (losses, hooks, initialization, accumulation, AMP, compile, TorchScript, packed sequences).
 
 ## Quick check command
 
@@ -32,3 +33,19 @@ python -m compileall pytorchlings/exercises pytorchlings/solutions
 ## Lightning note
 
 Exercises 25-27 expect `lightning` to be installed (`pip install lightning`).
+
+
+## Comprehensive PyTorch coverage extension
+
+Exercises 38-47 were added to cover production-focused PyTorch functionality that often gets skipped in beginner tracks:
+
+- Correct loss/logit pairings (`CrossEntropyLoss`, `BCEWithLogitsLoss`)
+- Device + dtype hygiene for stable training loops
+- Safe evaluation mode with `torch.no_grad()`
+- Forward hooks for feature extraction and debugging
+- Explicit parameter initialization patterns
+- Gradient accumulation over micro-batches
+- AMP (`autocast`, `GradScaler`)
+- `torch.compile` runtime optimization API
+- TorchScript export (`script`/`trace`)
+- Variable-length sequence modeling with packed RNN inputs

--- a/pytorchlings/exercises/38_losses_and_logits/losses_and_logits.py
+++ b/pytorchlings/exercises/38_losses_and_logits/losses_and_logits.py
@@ -1,0 +1,16 @@
+"""Exercise 38: choose correct loss usage from logits/probabilities."""
+import torch
+from torch import nn
+
+
+def compute_losses(logits: torch.Tensor, targets: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return (cross_entropy_loss, bce_with_logits_loss)."""
+    ce_targets = targets.long()
+    bce_targets = torch.nn.functional.one_hot(targets.long(), num_classes=logits.size(-1)).float()
+
+    # TODO: use nn.CrossEntropyLoss directly on logits + class indices
+    ce_loss = nn.CrossEntropyLoss()(torch.softmax(logits, dim=-1), ce_targets)
+
+    # TODO: use nn.BCEWithLogitsLoss on logits + one-hot float targets
+    bce_loss = nn.BCELoss()(torch.sigmoid(logits), bce_targets)
+    return ce_loss, bce_loss

--- a/pytorchlings/exercises/39_device_dtype/device_and_dtype.py
+++ b/pytorchlings/exercises/39_device_dtype/device_and_dtype.py
@@ -1,0 +1,14 @@
+"""Exercise 39: move tensors/model to the same device + dtype."""
+import torch
+from torch import nn
+
+
+def prepare_batch(model: nn.Module, x: torch.Tensor, y: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Move x,y to model device and cast x to float32, y to int64."""
+    # TODO: infer target device from model parameters
+    device = torch.device("cpu")
+
+    # TODO: move/cast tensors correctly
+    x = x
+    y = y
+    return x, y

--- a/pytorchlings/exercises/40_no_grad_inference/no_grad_eval.py
+++ b/pytorchlings/exercises/40_no_grad_inference/no_grad_eval.py
@@ -1,0 +1,11 @@
+"""Exercise 40: evaluation mode + no_grad inference."""
+import torch
+from torch import nn
+
+
+def predict(model: nn.Module, x: torch.Tensor) -> torch.Tensor:
+    """Run inference with dropout/batchnorm frozen and without grad tracking."""
+    # TODO: switch to eval mode
+
+    # TODO: run forward pass under torch.no_grad()
+    return model(x)

--- a/pytorchlings/exercises/41_hooks_and_features/forward_hook_capture.py
+++ b/pytorchlings/exercises/41_hooks_and_features/forward_hook_capture.py
@@ -1,0 +1,28 @@
+"""Exercise 41: use forward hooks to capture intermediate activations."""
+import torch
+from torch import nn
+
+
+class TinyCNN(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(1, 4, kernel_size=3, padding=1)
+        self.relu = nn.ReLU()
+        self.head = nn.Linear(4 * 8 * 8, 2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.relu(self.conv(x))
+        x = x.flatten(start_dim=1)
+        return self.head(x)
+
+
+def capture_conv_output(model: TinyCNN, x: torch.Tensor) -> torch.Tensor:
+    features: list[torch.Tensor] = []
+
+    def hook_fn(_module: nn.Module, _inp: tuple[torch.Tensor, ...], out: torch.Tensor) -> None:
+        features.append(out.detach())
+
+    # TODO: register hook on model.conv, run model(x), then remove hook
+    model(x)
+
+    return features[0]

--- a/pytorchlings/exercises/42_initialization/weight_init_strategies.py
+++ b/pytorchlings/exercises/42_initialization/weight_init_strategies.py
@@ -1,0 +1,19 @@
+"""Exercise 42: apply module-wise parameter initialization."""
+import torch
+from torch import nn
+
+
+class InitNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(16, 32)
+        self.act = nn.ReLU()
+        self.fc2 = nn.Linear(32, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.act(self.fc1(x)))
+
+
+def init_weights(model: InitNet) -> None:
+    # TODO: apply kaiming_uniform_ to Linear.weight and zeros_ to Linear.bias
+    pass

--- a/pytorchlings/exercises/43_gradient_accumulation/gradient_accumulation.py
+++ b/pytorchlings/exercises/43_gradient_accumulation/gradient_accumulation.py
@@ -1,0 +1,28 @@
+"""Exercise 43: gradient accumulation across micro-batches."""
+import torch
+from torch import nn
+
+
+def train_epoch_accum(
+    model: nn.Module,
+    optimizer: torch.optim.Optimizer,
+    loader,
+    accumulation_steps: int = 4,
+) -> float:
+    """Train for one epoch and step optimizer every accumulation_steps mini-batches."""
+    model.train()
+    criterion = nn.CrossEntropyLoss()
+    running = 0.0
+
+    optimizer.zero_grad()
+    for step_idx, (x, y) in enumerate(loader):
+        logits = model(x)
+        # TODO: divide by accumulation_steps before backward for equivalent gradients
+        loss = criterion(logits, y)
+        loss.backward()
+
+        # TODO: step/zero grad every accumulation_steps
+
+        running += loss.item()
+
+    return running / max(1, step_idx + 1)

--- a/pytorchlings/exercises/44_amp_basics/amp_training_step.py
+++ b/pytorchlings/exercises/44_amp_basics/amp_training_step.py
@@ -1,0 +1,20 @@
+"""Exercise 44: mixed precision training step with GradScaler."""
+import torch
+from torch import nn
+
+
+def amp_step(model: nn.Module, optimizer: torch.optim.Optimizer, x: torch.Tensor, y: torch.Tensor) -> float:
+    """Run one training step using autocast + GradScaler."""
+    model.train()
+    optimizer.zero_grad()
+    criterion = nn.CrossEntropyLoss()
+    scaler = torch.amp.GradScaler("cpu")
+
+    # TODO: wrap forward/loss with torch.autocast(device_type="cpu", dtype=torch.bfloat16)
+    logits = model(x)
+    loss = criterion(logits, y)
+
+    # TODO: scale(loss).backward(), scaler.step(optimizer), scaler.update()
+    loss.backward()
+    optimizer.step()
+    return float(loss.item())

--- a/pytorchlings/exercises/45_torch_compile/compile_smoke.py
+++ b/pytorchlings/exercises/45_torch_compile/compile_smoke.py
@@ -1,0 +1,17 @@
+"""Exercise 45: torch.compile smoke usage."""
+import torch
+from torch import nn
+
+
+class TinyMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(nn.Linear(8, 16), nn.GELU(), nn.Linear(16, 4))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+def compile_and_run(model: nn.Module, x: torch.Tensor) -> torch.Tensor:
+    # TODO: compile the model with torch.compile and run on x
+    return model(x)

--- a/pytorchlings/exercises/46_torchscript_export/torchscript_trace_script.py
+++ b/pytorchlings/exercises/46_torchscript_export/torchscript_trace_script.py
@@ -1,0 +1,9 @@
+"""Exercise 46: TorchScript scripting/tracing basics."""
+import torch
+from torch import nn
+
+
+def export_torchscript(model: nn.Module, example: torch.Tensor) -> torch.jit.ScriptModule:
+    """Return a TorchScript module generated from model."""
+    # TODO: script or trace the model with example input
+    return model  # type: ignore[return-value]

--- a/pytorchlings/exercises/47_packed_sequences/packed_sequence_rnn.py
+++ b/pytorchlings/exercises/47_packed_sequences/packed_sequence_rnn.py
@@ -1,0 +1,13 @@
+"""Exercise 47: variable-length RNN with pack/pad utilities."""
+import torch
+from torch import nn
+from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
+
+
+def run_packed_gru(x_padded: torch.Tensor, lengths: torch.Tensor, hidden_size: int = 8) -> torch.Tensor:
+    """Run a GRU over padded batch [B, T, F] and return unpacked outputs [B, T, H]."""
+    gru = nn.GRU(input_size=x_padded.size(-1), hidden_size=hidden_size, batch_first=True)
+
+    # TODO: pack with enforce_sorted=False, run GRU, then unpack with total_length
+    out, _ = gru(x_padded)
+    return out

--- a/pytorchlings/solutions/38_losses_and_logits.py
+++ b/pytorchlings/solutions/38_losses_and_logits.py
@@ -1,0 +1,11 @@
+import torch
+from torch import nn
+
+
+def compute_losses(logits: torch.Tensor, targets: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    ce_targets = targets.long()
+    bce_targets = torch.nn.functional.one_hot(targets.long(), num_classes=logits.size(-1)).float()
+
+    ce_loss = nn.CrossEntropyLoss()(logits, ce_targets)
+    bce_loss = nn.BCEWithLogitsLoss()(logits, bce_targets)
+    return ce_loss, bce_loss

--- a/pytorchlings/solutions/39_device_dtype.py
+++ b/pytorchlings/solutions/39_device_dtype.py
@@ -1,0 +1,9 @@
+import torch
+from torch import nn
+
+
+def prepare_batch(model: nn.Module, x: torch.Tensor, y: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    device = next(model.parameters()).device
+    x = x.to(device=device, dtype=torch.float32)
+    y = y.to(device=device, dtype=torch.int64)
+    return x, y

--- a/pytorchlings/solutions/40_no_grad_eval.py
+++ b/pytorchlings/solutions/40_no_grad_eval.py
@@ -1,0 +1,8 @@
+import torch
+from torch import nn
+
+
+def predict(model: nn.Module, x: torch.Tensor) -> torch.Tensor:
+    model.eval()
+    with torch.no_grad():
+        return model(x)

--- a/pytorchlings/solutions/41_forward_hook_capture.py
+++ b/pytorchlings/solutions/41_forward_hook_capture.py
@@ -1,0 +1,28 @@
+import torch
+from torch import nn
+
+
+class TinyCNN(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(1, 4, kernel_size=3, padding=1)
+        self.relu = nn.ReLU()
+        self.head = nn.Linear(4 * 8 * 8, 2)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.relu(self.conv(x))
+        x = x.flatten(start_dim=1)
+        return self.head(x)
+
+
+def capture_conv_output(model: TinyCNN, x: torch.Tensor) -> torch.Tensor:
+    features: list[torch.Tensor] = []
+
+    def hook_fn(_module: nn.Module, _inp: tuple[torch.Tensor, ...], out: torch.Tensor) -> None:
+        features.append(out.detach())
+
+    handle = model.conv.register_forward_hook(hook_fn)
+    _ = model(x)
+    handle.remove()
+
+    return features[0]

--- a/pytorchlings/solutions/42_weight_init_strategies.py
+++ b/pytorchlings/solutions/42_weight_init_strategies.py
@@ -1,0 +1,20 @@
+import torch
+from torch import nn
+
+
+class InitNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(16, 32)
+        self.act = nn.ReLU()
+        self.fc2 = nn.Linear(32, 4)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.act(self.fc1(x)))
+
+
+def init_weights(model: InitNet) -> None:
+    for module in model.modules():
+        if isinstance(module, nn.Linear):
+            nn.init.kaiming_uniform_(module.weight, nonlinearity="relu")
+            nn.init.zeros_(module.bias)

--- a/pytorchlings/solutions/43_gradient_accumulation.py
+++ b/pytorchlings/solutions/43_gradient_accumulation.py
@@ -1,0 +1,31 @@
+import torch
+from torch import nn
+
+
+def train_epoch_accum(
+    model: nn.Module,
+    optimizer: torch.optim.Optimizer,
+    loader,
+    accumulation_steps: int = 4,
+) -> float:
+    model.train()
+    criterion = nn.CrossEntropyLoss()
+    running = 0.0
+
+    optimizer.zero_grad()
+    for step_idx, (x, y) in enumerate(loader):
+        logits = model(x)
+        loss = criterion(logits, y) / accumulation_steps
+        loss.backward()
+
+        if (step_idx + 1) % accumulation_steps == 0:
+            optimizer.step()
+            optimizer.zero_grad()
+
+        running += loss.item() * accumulation_steps
+
+    if (step_idx + 1) % accumulation_steps != 0:
+        optimizer.step()
+        optimizer.zero_grad()
+
+    return running / max(1, step_idx + 1)

--- a/pytorchlings/solutions/44_amp_training_step.py
+++ b/pytorchlings/solutions/44_amp_training_step.py
@@ -1,0 +1,18 @@
+import torch
+from torch import nn
+
+
+def amp_step(model: nn.Module, optimizer: torch.optim.Optimizer, x: torch.Tensor, y: torch.Tensor) -> float:
+    model.train()
+    optimizer.zero_grad()
+    criterion = nn.CrossEntropyLoss()
+    scaler = torch.amp.GradScaler("cpu")
+
+    with torch.autocast(device_type="cpu", dtype=torch.bfloat16):
+        logits = model(x)
+        loss = criterion(logits, y)
+
+    scaler.scale(loss).backward()
+    scaler.step(optimizer)
+    scaler.update()
+    return float(loss.item())

--- a/pytorchlings/solutions/45_compile_smoke.py
+++ b/pytorchlings/solutions/45_compile_smoke.py
@@ -1,0 +1,16 @@
+import torch
+from torch import nn
+
+
+class TinyMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.net = nn.Sequential(nn.Linear(8, 16), nn.GELU(), nn.Linear(16, 4))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+def compile_and_run(model: nn.Module, x: torch.Tensor) -> torch.Tensor:
+    compiled = torch.compile(model)
+    return compiled(x)

--- a/pytorchlings/solutions/46_torchscript_trace_script.py
+++ b/pytorchlings/solutions/46_torchscript_trace_script.py
@@ -1,0 +1,9 @@
+import torch
+from torch import nn
+
+
+def export_torchscript(model: nn.Module, example: torch.Tensor) -> torch.jit.ScriptModule:
+    try:
+        return torch.jit.script(model)
+    except Exception:
+        return torch.jit.trace(model, example)

--- a/pytorchlings/solutions/47_packed_sequence_rnn.py
+++ b/pytorchlings/solutions/47_packed_sequence_rnn.py
@@ -1,0 +1,11 @@
+import torch
+from torch import nn
+from torch.nn.utils.rnn import pack_padded_sequence, pad_packed_sequence
+
+
+def run_packed_gru(x_padded: torch.Tensor, lengths: torch.Tensor, hidden_size: int = 8) -> torch.Tensor:
+    gru = nn.GRU(input_size=x_padded.size(-1), hidden_size=hidden_size, batch_first=True)
+    packed = pack_padded_sequence(x_padded, lengths.cpu(), batch_first=True, enforce_sorted=False)
+    packed_out, _ = gru(packed)
+    out, _ = pad_packed_sequence(packed_out, batch_first=True, total_length=x_padded.size(1))
+    return out


### PR DESCRIPTION
### Motivation
- Broaden the `pytorchlings` curriculum to cover intermediate-to-advanced, production-focused PyTorch engineering topics that learners often miss in beginner tracks. 
- Provide hands-on practice for patterns and APIs used in stable training loops and model deployment such as AMP, `torch.compile`, TorchScript, packed sequences, and correct loss usage.

### Description
- Added exercises `38`–`47` under `pytorchlings/exercises/` as TODO stubs and matching reference solutions under `pytorchlings/solutions/`, covering logits/loss pairing, device/dtype hygiene, eval/no-grad inference, forward hooks, weight initialization, gradient accumulation, AMP (`autocast` + `GradScaler`), `torch.compile`, TorchScript (`script`/`trace`), and packed-sequence RNNs. 
- Updated `pytorchlings/EXERCISES.md` to include entries for `38`–`47` and extended `pytorchlings/README.md` with a new section documenting the comprehensive PyTorch coverage and suggested flow. 
- Examples implemented in solutions include `nn.CrossEntropyLoss`/`nn.BCEWithLogitsLoss`, `next(model.parameters()).device` device inference, `model.eval()` + `torch.no_grad()`, forward-hook registration/removal, `nn.init.kaiming_uniform_` + zeroed biases, accumulation logic with scaled loss and conditional `optimizer.step()`, CPU-safe AMP usage, `torch.compile` call, TorchScript `script`/`trace` fallback, and packing/unpacking with `pack_padded_sequence`/`pad_packed_sequence`.

### Testing
- Ran `python -m compileall pytorchlings/exercises pytorchlings/solutions` and the modules compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cacf1355b4832eb3c1c2b4d46128b9)