### PR TITLE
Add introductory async exercises to py03lings

### DIFF
--- a/py03lings/EXERCISES.md
+++ b/py03lings/EXERCISES.md
@@ -6,3 +6,6 @@
 | 01 | conditionals and loops | `exercises/01_control_flow/control_flow.py` | `solutions/01_control_flow.py` |
 | 02 | list/dict transformations | `exercises/02_collections/collections_ops.py` | `solutions/02_collections_ops.py` |
 | 03 | function defaults and kwargs | `exercises/03_functions/keyword_report.py` | `solutions/03_keyword_report.py` |
+
+| 04 | asyncio basics (`async`/`await`) | `exercises/04_async_sleep/async_sleep.py` | `solutions/04_async_sleep.py` |
+| 05 | async concurrency with `gather` | `exercises/05_async_gather/async_gather.py` | `solutions/05_async_gather.py` |

--- a/py03lings/README.md
+++ b/py03lings/README.md
@@ -1,6 +1,6 @@
 # py03lings
 
-A rustlings-style practice track for Python 3 fundamentals.
+A rustlings-style practice track for Python 3 fundamentals, including intro async exercises.
 
 ## How to use
 

--- a/py03lings/exercises/04_async_sleep/async_sleep.py
+++ b/py03lings/exercises/04_async_sleep/async_sleep.py
@@ -1,0 +1,18 @@
+"""Exercise 04: write a simple async function and run it."""
+
+import asyncio
+
+
+async def delayed_upper(text: str, delay: float) -> str:
+    # TODO: await asyncio.sleep(delay)
+    # TODO: return the uppercased text
+    return ""
+
+
+async def main() -> None:
+    result = await delayed_upper("chemistry", 0.01)
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/py03lings/exercises/05_async_gather/async_gather.py
+++ b/py03lings/exercises/05_async_gather/async_gather.py
@@ -1,0 +1,24 @@
+"""Exercise 05: run async tasks concurrently with gather."""
+
+import asyncio
+
+
+async def fetch_label(label: str, delay: float) -> str:
+    # TODO: await asyncio.sleep(delay)
+    # TODO: return f"done:{label}"
+    return ""
+
+
+async def run_batch() -> list[str]:
+    # TODO: run fetch_label for A (0.02), B (0.01), C (0.03) concurrently
+    # TODO: return results from asyncio.gather(...)
+    return []
+
+
+async def main() -> None:
+    results = await run_batch()
+    print(", ".join(results))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/py03lings/solutions/04_async_sleep.py
+++ b/py03lings/solutions/04_async_sleep.py
@@ -1,0 +1,17 @@
+"""Solution 04: write a simple async function and run it."""
+
+import asyncio
+
+
+async def delayed_upper(text: str, delay: float) -> str:
+    await asyncio.sleep(delay)
+    return text.upper()
+
+
+async def main() -> None:
+    result = await delayed_upper("chemistry", 0.01)
+    print(result)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/py03lings/solutions/05_async_gather.py
+++ b/py03lings/solutions/05_async_gather.py
@@ -1,0 +1,25 @@
+"""Solution 05: run async tasks concurrently with gather."""
+
+import asyncio
+
+
+async def fetch_label(label: str, delay: float) -> str:
+    await asyncio.sleep(delay)
+    return f"done:{label}"
+
+
+async def run_batch() -> list[str]:
+    return await asyncio.gather(
+        fetch_label("A", 0.02),
+        fetch_label("B", 0.01),
+        fetch_label("C", 0.03),
+    )
+
+
+async def main() -> None:
+    results = await run_batch()
+    print(", ".join(results))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
### Motivation

- Teach basic `asyncio` usage by adding short, focused exercises covering `async`/`await` and concurrent tasks with `gather`.
- Provide worked solutions so learners can run and compare correct implementations for the new async topics.

### Description

- Add two exercise stubs: `py03lings/exercises/04_async_sleep/async_sleep.py` (async/await basics) and `py03lings/exercises/05_async_gather/async_gather.py` (concurrency with `asyncio.gather`).
- Add matching solutions in `py03lings/solutions/04_async_sleep.py` and `py03lings/solutions/05_async_gather.py` implementing `asyncio.sleep`, uppercasing, and `gather` usage.
- Update the exercise index `py03lings/EXERCISES.md` to include entries for exercises `04` and `05`.
- Update `py03lings/README.md` to mention that the track includes intro async exercises.

### Testing

- Ran `python py03lings/check.py` to list exercises and TODO counts, which completed successfully.
- Ran `python -m compileall py03lings/exercises py03lings/solutions` to byte-compile the exercises and solutions, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbb7355664832ea88040f8cd1e85de)