### PR TITLE
Add AIMMS-style linear programming exercises to py03lings

### DIFF
--- a/py03lings/EXERCISES.md
+++ b/py03lings/EXERCISES.md
@@ -9,3 +9,7 @@
 
 | 04 | asyncio basics (`async`/`await`) | `exercises/04_async_sleep/async_sleep.py` | `solutions/04_async_sleep.py` |
 | 05 | async concurrency with `gather` | `exercises/05_async_gather/async_gather.py` | `solutions/05_async_gather.py` |
+
+| 06 | linear programming (blending model with PuLP) | `exercises/06_lp_blending/lp_blending.py` | `solutions/06_lp_blending.py` |
+| 07 | linear programming (multi-period planning) | `exercises/07_lp_production_planning/lp_production_planning.py` | `solutions/07_lp_production_planning.py` |
+| 08 | linear programming (transportation model) | `exercises/08_lp_transportation/lp_transportation.py` | `solutions/08_lp_transportation.py` |

--- a/py03lings/README.md
+++ b/py03lings/README.md
@@ -15,3 +15,14 @@ A rustlings-style practice track for Python 3 fundamentals, including intro asyn
 python py03lings/check.py
 python -m compileall py03lings/exercises py03lings/solutions
 ```
+
+
+## Linear programming track (AIMMS-style modeling in Python)
+
+For LP exercises 06-08, install PuLP first:
+
+```bash
+pip install pulp
+```
+
+These exercises focus on optimization modeling patterns similar to AIMMS, but fully in Python.

--- a/py03lings/exercises/06_lp_blending/lp_blending.py
+++ b/py03lings/exercises/06_lp_blending/lp_blending.py
@@ -1,0 +1,42 @@
+"""Exercise 06: linear programming blending model with PuLP.
+
+Goal: maximize profit for a 2-product production plan.
+
+Install once:
+    pip install pulp
+"""
+
+import pulp
+
+
+# Profit per unit
+PROFIT_REGULAR = 30
+PROFIT_DELUXE = 50
+
+
+def build_and_solve() -> tuple[float, float, float]:
+    """Return (regular_units, deluxe_units, max_profit)."""
+    # TODO: create a maximization problem named "blending"
+    problem = None
+
+    # TODO: create non-negative variables regular and deluxe
+    regular = None
+    deluxe = None
+
+    # TODO: add objective: maximize 30*regular + 50*deluxe
+
+    # Hours limits
+    # Mixing: 1*regular + 2*deluxe <= 40
+    # Packaging: 2*regular + 1*deluxe <= 50
+    # TODO: add both constraints
+
+    # TODO: solve the model
+
+    # TODO: return solution tuple as floats:
+    # (regular_value, deluxe_value, objective_value)
+    return 0.0, 0.0, 0.0
+
+
+if __name__ == "__main__":
+    regular, deluxe, profit = build_and_solve()
+    print(f"regular={regular:.2f}, deluxe={deluxe:.2f}, profit={profit:.2f}")

--- a/py03lings/exercises/07_lp_production_planning/lp_production_planning.py
+++ b/py03lings/exercises/07_lp_production_planning/lp_production_planning.py
@@ -1,0 +1,46 @@
+"""Exercise 07: multi-period production planning LP with PuLP.
+
+Install once:
+    pip install pulp
+"""
+
+import pulp
+
+
+def plan_production() -> dict[str, float]:
+    """Solve and return decision values keyed by variable name."""
+    months = ["m1", "m2", "m3"]
+    demand = {"m1": 30, "m2": 40, "m3": 35}
+    prod_cost = {"m1": 5, "m2": 4, "m3": 6}
+    hold_cost = 1
+    max_prod = 50
+
+    # TODO: create minimization problem "production_planning"
+    model = None
+
+    # TODO: create non-negative production vars prod[m]
+    prod = None
+
+    # TODO: create non-negative inventory vars inv[m]
+    inv = None
+
+    # TODO: objective = sum(prod_cost[m]*prod[m] + hold_cost*inv[m])
+
+    # Inventory balance:
+    # inv[m1] = prod[m1] - demand[m1]
+    # inv[m2] = inv[m1] + prod[m2] - demand[m2]
+    # inv[m3] = inv[m2] + prod[m3] - demand[m3]
+    # TODO: encode these constraints
+
+    # TODO: add production capacity constraints prod[m] <= max_prod
+
+    # TODO: solve silently with CBC
+
+    # TODO: return a dict containing prod_*, inv_*, and total_cost
+    return {}
+
+
+if __name__ == "__main__":
+    result = plan_production()
+    for k, v in result.items():
+        print(f"{k}: {v:.2f}")

--- a/py03lings/exercises/08_lp_transportation/lp_transportation.py
+++ b/py03lings/exercises/08_lp_transportation/lp_transportation.py
@@ -1,0 +1,49 @@
+"""Exercise 08: transportation LP with PuLP.
+
+Install once:
+    pip install pulp
+"""
+
+import pulp
+
+
+def optimize_shipping() -> dict[str, float]:
+    plants = ["A", "B"]
+    warehouses = ["X", "Y", "Z"]
+
+    supply = {"A": 70, "B": 60}
+    demand = {"X": 40, "Y": 50, "Z": 40}
+
+    cost = {
+        ("A", "X"): 4,
+        ("A", "Y"): 6,
+        ("A", "Z"): 8,
+        ("B", "X"): 5,
+        ("B", "Y"): 4,
+        ("B", "Z"): 3,
+    }
+
+    # TODO: create minimization model "transportation"
+    model = None
+
+    # TODO: create non-negative shipment vars ship[(p, w)]
+    ship = None
+
+    # TODO: objective = sum(cost[(p,w)] * ship[(p,w)])
+
+    # TODO: supply constraints for each plant
+    # sum_w ship[(p,w)] <= supply[p]
+
+    # TODO: demand constraints for each warehouse
+    # sum_p ship[(p,w)] >= demand[w]
+
+    # TODO: solve silently with CBC
+
+    # TODO: return dict with each route and total_cost
+    return {}
+
+
+if __name__ == "__main__":
+    answer = optimize_shipping()
+    for k, v in answer.items():
+        print(f"{k}: {v:.2f}")

--- a/py03lings/solutions/06_lp_blending.py
+++ b/py03lings/solutions/06_lp_blending.py
@@ -1,0 +1,32 @@
+"""Solution 06: linear programming blending model with PuLP."""
+
+import pulp
+
+
+PROFIT_REGULAR = 30
+PROFIT_DELUXE = 50
+
+
+def build_and_solve() -> tuple[float, float, float]:
+    problem = pulp.LpProblem("blending", pulp.LpMaximize)
+
+    regular = pulp.LpVariable("regular", lowBound=0)
+    deluxe = pulp.LpVariable("deluxe", lowBound=0)
+
+    problem += PROFIT_REGULAR * regular + PROFIT_DELUXE * deluxe
+
+    problem += regular + 2 * deluxe <= 40
+    problem += 2 * regular + deluxe <= 50
+
+    problem.solve(pulp.PULP_CBC_CMD(msg=False))
+
+    return (
+        float(regular.value()),
+        float(deluxe.value()),
+        float(pulp.value(problem.objective)),
+    )
+
+
+if __name__ == "__main__":
+    regular, deluxe, profit = build_and_solve()
+    print(f"regular={regular:.2f}, deluxe={deluxe:.2f}, profit={profit:.2f}")

--- a/py03lings/solutions/07_lp_production_planning.py
+++ b/py03lings/solutions/07_lp_production_planning.py
@@ -1,0 +1,38 @@
+"""Solution 07: multi-period production planning LP with PuLP."""
+
+import pulp
+
+
+def plan_production() -> dict[str, float]:
+    months = ["m1", "m2", "m3"]
+    demand = {"m1": 30, "m2": 40, "m3": 35}
+    prod_cost = {"m1": 5, "m2": 4, "m3": 6}
+    hold_cost = 1
+    max_prod = 50
+
+    model = pulp.LpProblem("production_planning", pulp.LpMinimize)
+
+    prod = pulp.LpVariable.dicts("prod", months, lowBound=0)
+    inv = pulp.LpVariable.dicts("inv", months, lowBound=0)
+
+    model += pulp.lpSum(prod_cost[m] * prod[m] + hold_cost * inv[m] for m in months)
+
+    model += inv["m1"] == prod["m1"] - demand["m1"]
+    model += inv["m2"] == inv["m1"] + prod["m2"] - demand["m2"]
+    model += inv["m3"] == inv["m2"] + prod["m3"] - demand["m3"]
+
+    for m in months:
+        model += prod[m] <= max_prod
+
+    model.solve(pulp.PULP_CBC_CMD(msg=False))
+
+    result = {f"prod_{m}": float(prod[m].value()) for m in months}
+    result.update({f"inv_{m}": float(inv[m].value()) for m in months})
+    result["total_cost"] = float(pulp.value(model.objective))
+    return result
+
+
+if __name__ == "__main__":
+    result = plan_production()
+    for k, v in result.items():
+        print(f"{k}: {v:.2f}")

--- a/py03lings/solutions/08_lp_transportation.py
+++ b/py03lings/solutions/08_lp_transportation.py
@@ -1,0 +1,48 @@
+"""Solution 08: transportation LP with PuLP."""
+
+import pulp
+
+
+def optimize_shipping() -> dict[str, float]:
+    plants = ["A", "B"]
+    warehouses = ["X", "Y", "Z"]
+
+    supply = {"A": 70, "B": 60}
+    demand = {"X": 40, "Y": 50, "Z": 40}
+
+    cost = {
+        ("A", "X"): 4,
+        ("A", "Y"): 6,
+        ("A", "Z"): 8,
+        ("B", "X"): 5,
+        ("B", "Y"): 4,
+        ("B", "Z"): 3,
+    }
+
+    model = pulp.LpProblem("transportation", pulp.LpMinimize)
+
+    ship = pulp.LpVariable.dicts(
+        "ship",
+        [(p, w) for p in plants for w in warehouses],
+        lowBound=0,
+    )
+
+    model += pulp.lpSum(cost[(p, w)] * ship[(p, w)] for p in plants for w in warehouses)
+
+    for p in plants:
+        model += pulp.lpSum(ship[(p, w)] for w in warehouses) <= supply[p]
+
+    for w in warehouses:
+        model += pulp.lpSum(ship[(p, w)] for p in plants) >= demand[w]
+
+    model.solve(pulp.PULP_CBC_CMD(msg=False))
+
+    out = {f"ship_{p}_{w}": float(ship[(p, w)].value()) for p in plants for w in warehouses}
+    out["total_cost"] = float(pulp.value(model.objective))
+    return out
+
+
+if __name__ == "__main__":
+    answer = optimize_shipping()
+    for k, v in answer.items():
+        print(f"{k}: {v:.2f}")


### PR DESCRIPTION
### Motivation

- Add a small linear-programming track to the existing Python exercise set so learners can practice optimization-modeling workflows similar to AIMMS but implemented in Python.
- Provide approachable, self-contained LP examples (blending, multi-period planning, transportation) that illustrate modeling patterns and solver usage with PuLP.

### Description

- Add three new exercise stubs with `TODO`s: `py03lings/exercises/06_lp_blending/lp_blending.py`, `py03lings/exercises/07_lp_production_planning/lp_production_planning.py`, and `py03lings/exercises/08_lp_transportation/lp_transportation.py` that use PuLP for modeling.
- Add matching reference solutions in `py03lings/solutions/06_lp_blending.py`, `py03lings/solutions/07_lp_production_planning.py`, and `py03lings/solutions/08_lp_transportation.py` that build and solve the LPs using CBC.
- Update the exercise index `py03lings/EXERCISES.md` to list exercises 06–08 and extend `py03lings/README.md` with a new "Linear programming track" section and `pip install pulp` guidance.

### Testing

- Ran `python py03lings/check.py` to enumerate exercises and TODO counts, which executed successfully and listed the new exercises.
- Ran `python -m compileall py03lings/exercises py03lings/solutions` to verify modules compile, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce567b2e2c832ea99cc33683d8a9da)