### PR TITLE
Add Optuna exercises for PyTorch MLP and scikit-learn RandomForest baselines

### DIFF
--- a/pytorchlings/EXERCISES.md
+++ b/pytorchlings/EXERCISES.md
@@ -65,3 +65,5 @@
 | 57 | PyG | Graph Transformer convolution | `exercises/57_graph_transformer/graph_transformer_conv.py` | `solutions/57_graph_transformer_conv.py` |
 | 58 | PyG | Graph Autoencoder (encode/decode) | `exercises/58_graph_autoencoder/graph_autoencoder.py` | `solutions/58_graph_autoencoder.py` |
 | 59 | PyG | Diffusion-based GNN (APPNP) | `exercises/59_diffusion_gnn/appnp_diffusion.py` | `solutions/59_appnp_diffusion.py` |
+| 60 | PyTorch + Optuna | Hyperparameter tuning for MLP classification | `exercises/60_optuna_tuning/optuna_pytorch_mlp.py` | `solutions/60_optuna_pytorch_mlp.py` |
+| 61 | Scikit-learn + Optuna | Tune RandomForest baseline with CV | `exercises/61_optuna_baselines/optuna_sklearn_baseline.py` | `solutions/61_optuna_sklearn_baseline.py` |

--- a/pytorchlings/README.md
+++ b/pytorchlings/README.md
@@ -21,6 +21,7 @@ A rustlings-style practice track for **PyTorch** and **PyTorch Geometric (PyG)**
 - Add 35-37 for PyG GraphGym config, registration, and experiment YAML practice.
 - Complete 38-47 for comprehensive PyTorch engineering workflows (losses, hooks, initialization, accumulation, AMP, compile, TorchScript, packed sequences).
 - Continue 48-59 for advanced graph architecture coverage (GCN, GAT, GraphSAGE, GIN, spectral, pooling, hyperbolic, dynamic, R-GCN, graph transformer, graph autoencoder, diffusion).
+- Add 60-61 for Optuna-based hyperparameter optimization (PyTorch MLP + scikit-learn baseline tuning).
 
 ## Quick check command
 
@@ -68,3 +69,12 @@ Exercises 48-59 extend PyG graph learning coverage across major model families:
 - Graph Transformer
 - Graph Autoencoder
 - Diffusion-style propagation (APPNP)
+
+## Hyperparameter optimization extension
+
+Exercises 60-61 introduce Optuna workflows so learners can practice search-space design and reproducible studies:
+
+- Optuna trial definitions for PyTorch model architecture/training hyperparameters
+- Intermediate metric reporting + pruning hooks
+- TPE and random samplers with fixed seeds
+- Non-neural baseline tuning with scikit-learn cross-validation

--- a/pytorchlings/exercises/60_optuna_tuning/optuna_pytorch_mlp.py
+++ b/pytorchlings/exercises/60_optuna_tuning/optuna_pytorch_mlp.py
@@ -1,0 +1,109 @@
+"""Exercise 60: tune a small PyTorch MLP with Optuna.
+
+Install dependency first:
+    pip install optuna
+"""
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+
+def make_toy_data(n: int = 512) -> tuple[torch.Tensor, torch.Tensor]:
+    """Binary classification toy data (two noisy circles)."""
+    g = torch.Generator().manual_seed(7)
+    r = torch.rand(n, generator=g)
+    theta = torch.rand(n, generator=g) * (2.0 * math.pi)
+    x = torch.stack([r * torch.cos(theta), r * torch.sin(theta)], dim=1)
+    y = (r > 0.55).long()
+    x = x + 0.05 * torch.randn_like(x, generator=g)
+    return x, y
+
+
+def build_model(hidden_dim: int, dropout: float) -> nn.Module:
+    """Return a tiny MLP for 2D -> 2-class classification."""
+    return nn.Sequential(
+        nn.Linear(2, hidden_dim),
+        nn.ReLU(),
+        nn.Dropout(dropout),
+        nn.Linear(hidden_dim, 2),
+    )
+
+
+def train_epoch(model: nn.Module, loader: DataLoader, optimizer: torch.optim.Optimizer) -> float:
+    """Run one epoch and return mean loss."""
+    model.train()
+    criterion = nn.CrossEntropyLoss()
+    running_loss = 0.0
+    total = 0
+    for xb, yb in loader:
+        optimizer.zero_grad()
+        logits = model(xb)
+        loss = criterion(logits, yb)
+        loss.backward()
+        optimizer.step()
+        running_loss += float(loss.item()) * xb.size(0)
+        total += xb.size(0)
+    return running_loss / max(total, 1)
+
+
+def evaluate_accuracy(model: nn.Module, x: torch.Tensor, y: torch.Tensor) -> float:
+    """Return classification accuracy in [0, 1]."""
+    model.eval()
+    with torch.no_grad():
+        pred = model(x).argmax(dim=1)
+    return float((pred == y).float().mean().item())
+
+
+def objective(trial, train_loader: DataLoader, x_val: torch.Tensor, y_val: torch.Tensor) -> float:
+    """Optuna objective: maximize validation accuracy."""
+    # TODO: sample hidden_dim in [8, 128] (step=8) with suggest_int.
+    hidden_dim = 32
+    # TODO: sample dropout in [0.0, 0.5] with suggest_float.
+    dropout = 0.1
+    # TODO: sample learning rate log-uniform in [1e-4, 1e-1].
+    lr = 1e-3
+
+    model = build_model(hidden_dim=hidden_dim, dropout=dropout)
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+
+    # TODO: sample number of epochs in [5, 30] and train for that many epochs.
+    for _ in range(5):
+        train_epoch(model, train_loader, optimizer)
+
+    # TODO: report intermediate values for pruning and return final val accuracy.
+    return evaluate_accuracy(model, x_val, y_val)
+
+
+def run_study(n_trials: int = 20):
+    """Create and run an Optuna study."""
+    import optuna
+
+    x, y = make_toy_data(n=1024)
+    split = 768
+    x_train, y_train = x[:split], y[:split]
+    x_val, y_val = x[split:], y[split:]
+    train_loader = DataLoader(TensorDataset(x_train, y_train), batch_size=64, shuffle=True)
+
+    # TODO: use TPESampler with seed=123.
+    sampler = None
+    # TODO: use MedianPruner(n_startup_trials=5, n_warmup_steps=2).
+    pruner = None
+
+    study = optuna.create_study(
+        direction="maximize",
+        sampler=sampler,
+        pruner=pruner,
+        study_name="pytorch_mlp_tuning",
+    )
+    study.optimize(lambda trial: objective(trial, train_loader, x_val, y_val), n_trials=n_trials)
+    return study
+
+
+if __name__ == "__main__":
+    study = run_study(n_trials=10)
+    print("Best value:", study.best_value)
+    print("Best params:", study.best_params)

--- a/pytorchlings/exercises/61_optuna_baselines/optuna_sklearn_baseline.py
+++ b/pytorchlings/exercises/61_optuna_baselines/optuna_sklearn_baseline.py
@@ -1,0 +1,63 @@
+"""Exercise 61: Optuna search over non-PyTorch baselines.
+
+Install dependencies first:
+    pip install optuna scikit-learn
+"""
+from __future__ import annotations
+
+from sklearn.datasets import make_classification
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import cross_val_score
+
+
+def make_data():
+    """Create a tabular binary classification dataset."""
+    x, y = make_classification(
+        n_samples=700,
+        n_features=20,
+        n_informative=10,
+        n_redundant=3,
+        class_sep=1.2,
+        flip_y=0.02,
+        random_state=42,
+    )
+    return x, y
+
+
+def objective(trial, x, y) -> float:
+    """Optuna objective for RandomForest mean CV accuracy."""
+    # TODO: suggest n_estimators in [50, 300] step 25.
+    n_estimators = 100
+    # TODO: suggest max_depth in [2, 20].
+    max_depth = 8
+    # TODO: suggest min_samples_split in [2, 12].
+    min_samples_split = 2
+
+    model = RandomForestClassifier(
+        n_estimators=n_estimators,
+        max_depth=max_depth,
+        min_samples_split=min_samples_split,
+        random_state=123,
+        n_jobs=-1,
+    )
+
+    scores = cross_val_score(model, x, y, cv=5, scoring="accuracy", n_jobs=-1)
+    return float(scores.mean())
+
+
+def run_study(n_trials: int = 30):
+    """Run and return a study for tabular baseline tuning."""
+    import optuna
+
+    x, y = make_data()
+    # TODO: use RandomSampler(seed=1234).
+    sampler = None
+    study = optuna.create_study(direction="maximize", sampler=sampler, study_name="rf_baseline_tuning")
+    study.optimize(lambda trial: objective(trial, x, y), n_trials=n_trials)
+    return study
+
+
+if __name__ == "__main__":
+    study = run_study(n_trials=10)
+    print("Best score:", study.best_value)
+    print("Best params:", study.best_params)

--- a/pytorchlings/solutions/60_optuna_pytorch_mlp.py
+++ b/pytorchlings/solutions/60_optuna_pytorch_mlp.py
@@ -1,0 +1,99 @@
+"""Solution 60: tune a small PyTorch MLP with Optuna."""
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+
+def make_toy_data(n: int = 512) -> tuple[torch.Tensor, torch.Tensor]:
+    g = torch.Generator().manual_seed(7)
+    r = torch.rand(n, generator=g)
+    theta = torch.rand(n, generator=g) * (2.0 * math.pi)
+    x = torch.stack([r * torch.cos(theta), r * torch.sin(theta)], dim=1)
+    y = (r > 0.55).long()
+    x = x + 0.05 * torch.randn_like(x, generator=g)
+    return x, y
+
+
+def build_model(hidden_dim: int, dropout: float) -> nn.Module:
+    return nn.Sequential(
+        nn.Linear(2, hidden_dim),
+        nn.ReLU(),
+        nn.Dropout(dropout),
+        nn.Linear(hidden_dim, 2),
+    )
+
+
+def train_epoch(model: nn.Module, loader: DataLoader, optimizer: torch.optim.Optimizer) -> float:
+    model.train()
+    criterion = nn.CrossEntropyLoss()
+    running_loss = 0.0
+    total = 0
+    for xb, yb in loader:
+        optimizer.zero_grad()
+        logits = model(xb)
+        loss = criterion(logits, yb)
+        loss.backward()
+        optimizer.step()
+        running_loss += float(loss.item()) * xb.size(0)
+        total += xb.size(0)
+    return running_loss / max(total, 1)
+
+
+def evaluate_accuracy(model: nn.Module, x: torch.Tensor, y: torch.Tensor) -> float:
+    model.eval()
+    with torch.no_grad():
+        pred = model(x).argmax(dim=1)
+    return float((pred == y).float().mean().item())
+
+
+def objective(trial, train_loader: DataLoader, x_val: torch.Tensor, y_val: torch.Tensor) -> float:
+    hidden_dim = trial.suggest_int("hidden_dim", 8, 128, step=8)
+    dropout = trial.suggest_float("dropout", 0.0, 0.5)
+    lr = trial.suggest_float("lr", 1e-4, 1e-1, log=True)
+    epochs = trial.suggest_int("epochs", 5, 30)
+
+    model = build_model(hidden_dim=hidden_dim, dropout=dropout)
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+
+    for epoch in range(epochs):
+        train_epoch(model, train_loader, optimizer)
+        val_acc = evaluate_accuracy(model, x_val, y_val)
+        trial.report(val_acc, step=epoch)
+        if trial.should_prune():
+            import optuna
+
+            raise optuna.TrialPruned()
+
+    return evaluate_accuracy(model, x_val, y_val)
+
+
+def run_study(n_trials: int = 20):
+    import optuna
+
+    x, y = make_toy_data(n=1024)
+    split = 768
+    x_train, y_train = x[:split], y[:split]
+    x_val, y_val = x[split:], y[split:]
+    train_loader = DataLoader(TensorDataset(x_train, y_train), batch_size=64, shuffle=True)
+
+    sampler = optuna.samplers.TPESampler(seed=123)
+    pruner = optuna.pruners.MedianPruner(n_startup_trials=5, n_warmup_steps=2)
+
+    study = optuna.create_study(
+        direction="maximize",
+        sampler=sampler,
+        pruner=pruner,
+        study_name="pytorch_mlp_tuning",
+    )
+    study.optimize(lambda trial: objective(trial, train_loader, x_val, y_val), n_trials=n_trials)
+    return study
+
+
+if __name__ == "__main__":
+    study = run_study(n_trials=10)
+    print("Best value:", study.best_value)
+    print("Best params:", study.best_params)

--- a/pytorchlings/solutions/61_optuna_sklearn_baseline.py
+++ b/pytorchlings/solutions/61_optuna_sklearn_baseline.py
@@ -1,0 +1,52 @@
+"""Solution 61: Optuna search over non-PyTorch baselines."""
+from __future__ import annotations
+
+from sklearn.datasets import make_classification
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import cross_val_score
+
+
+def make_data():
+    x, y = make_classification(
+        n_samples=700,
+        n_features=20,
+        n_informative=10,
+        n_redundant=3,
+        class_sep=1.2,
+        flip_y=0.02,
+        random_state=42,
+    )
+    return x, y
+
+
+def objective(trial, x, y) -> float:
+    n_estimators = trial.suggest_int("n_estimators", 50, 300, step=25)
+    max_depth = trial.suggest_int("max_depth", 2, 20)
+    min_samples_split = trial.suggest_int("min_samples_split", 2, 12)
+
+    model = RandomForestClassifier(
+        n_estimators=n_estimators,
+        max_depth=max_depth,
+        min_samples_split=min_samples_split,
+        random_state=123,
+        n_jobs=-1,
+    )
+
+    scores = cross_val_score(model, x, y, cv=5, scoring="accuracy", n_jobs=-1)
+    return float(scores.mean())
+
+
+def run_study(n_trials: int = 30):
+    import optuna
+
+    x, y = make_data()
+    sampler = optuna.samplers.RandomSampler(seed=1234)
+    study = optuna.create_study(direction="maximize", sampler=sampler, study_name="rf_baseline_tuning")
+    study.optimize(lambda trial: objective(trial, x, y), n_trials=n_trials)
+    return study
+
+
+if __name__ == "__main__":
+    study = run_study(n_trials=10)
+    print("Best score:", study.best_value)
+    print("Best params:", study.best_params)


### PR DESCRIPTION
### Motivation
- Provide hands-on Optuna examples so learners can practice hyperparameter search with a PyTorch model and a non-neural baseline.
- Teach reproducible study setup, sampler/pruner choices, and intermediate reporting/pruning in a compact, runnable form.

### Description
- Add new exercise `60` at `pytorchlings/exercises/60_optuna_tuning/optuna_pytorch_mlp.py` that scaffolds tuning a small 2D MLP with TODOs for search-space and pruning hooks. 
- Add corresponding solution `pytorchlings/solutions/60_optuna_pytorch_mlp.py` that implements `trial.suggest_*`, intermediate `trial.report`/`trial.should_prune`, a `TPESampler(seed=123)`, and `MedianPruner` usage. 
- Add new exercise `61` at `pytorchlings/exercises/61_optuna_baselines/optuna_sklearn_baseline.py` for tuning a `RandomForestClassifier` with CV-based objective and TODOs for sampler/parameter suggestions. 
- Add corresponding solution `pytorchlings/solutions/61_optuna_sklearn_baseline.py` that implements `trial.suggest_*`, `RandomSampler(seed=1234)`, and 5-fold cross-validation evaluation, and update `pytorchlings/EXERCISES.md` and `pytorchlings/README.md` to list and document exercises `60` and `61`.

### Testing
- Ran bytecode compilation with `python -m compileall pytorchlings/exercises/60_optuna_tuning/optuna_pytorch_mlp.py pytorchlings/exercises/61_optuna_baselines/optuna_sklearn_baseline.py pytorchlings/solutions/60_optuna_pytorch_mlp.py pytorchlings/solutions/61_optuna_sklearn_baseline.py` and it completed without errors. 
- Verified the new exercise entries appear in `pytorchlings/EXERCISES.md` and the README update shows the new Optuna extension section.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf7d84951c832e893b893483665afe)