### PR TITLE
Clean up GIN graph model implementation

### DIFF
--- a/src/pytorch_practice/graph/torch_gin_implementation.py
+++ b/src/pytorch_practice/graph/torch_gin_implementation.py
@@ -1,27 +1,43 @@
 import torch
 import torch.nn.functional as F
-
-from torch_geometric.nn import GCNConv, global_mean_pool, GraphConv
-from torch_geometric.data import Data, DataLoader
 from torch.nn import Linear
+from torch_geometric.nn import GraphConv, global_mean_pool
 
 
 class GIN(torch.nn.Module):
-    def __init__(self, hidden_channels, dataset):
-        super(GIN, self).__init__()
-        self.conv_gin1 = GraphConv(dataset.num_node_features, hidden_channels)
+    """Simple graph classification model using GraphConv layers.
+
+    Notes:
+    - Despite the class name, this currently uses ``GraphConv`` blocks.
+    - Inputs follow the standard PyG ``Data`` batch signature.
+    """
+
+    def __init__(self, hidden_channels: int, dataset) -> None:
+        super().__init__()
+        in_channels = dataset.num_node_features
+        out_channels = dataset.num_classes
+
+        self.conv1 = GraphConv(in_channels, hidden_channels)
         self.conv2 = GraphConv(hidden_channels, hidden_channels)
         self.conv3 = GraphConv(hidden_channels, hidden_channels)
-        self.lin = Linear(hidden_channels, dataset.num_classes)
-        
+        self.classifier = Linear(hidden_channels, out_channels)
+
     def forward(self, x, edge_index, batch):
-        x = self.conv1(x, edge_index) # 1-hop neighbours 
+        """Run a forward pass.
+
+        Args:
+            x: Node feature matrix with shape [num_nodes, num_node_features].
+            edge_index: Graph connectivity in COO format.
+            batch: Batch vector that maps each node to a graph id.
+        """
+        x = self.conv1(x, edge_index)
         x = x.relu()
-        x = self.conv2(x, edge_index) # 2-hop neighbours 
+
+        x = self.conv2(x, edge_index)
         x = x.relu()
-        x = self.conv3(x, edge_index) # larger structural context 
-        x = global_mean_pool(x, batch) # converts the node features -> graph embeddin
-        
-        x = F.dropout(x, p = 0.5, training = self.training)
-        x = self.lin(x)
-        return x
+
+        x = self.conv3(x, edge_index)
+        x = global_mean_pool(x, batch)
+
+        x = F.dropout(x, p=0.5, training=self.training)
+        return self.classifier(x)


### PR DESCRIPTION
### Motivation
- Fix a runtime-breaking attribute mismatch in the GIN model where a non-existent convolution (`conv_gin1`) was referenced, causing `forward` to fail. 
- Improve readability, consistency, and maintainability of the model implementation for downstream use in PyG experiments.

### Description
- Rewrote `src/pytorch_practice/graph/torch_gin_implementation.py` to use consistent layer names and clearer variable names (`in_channels`, `out_channels`, `classifier`).
- Replaced the broken `conv_gin1` attribute with `conv1` and ensured `forward` uses `self.conv1`, `self.conv2`, and `self.conv3` in order.
- Removed unused imports and simplified import list to only the required symbols from `torch` and `torch_geometric`.
- Added concise class and method docstrings and a couple of type hints for constructor parameters.

### Testing
- Ran `python -m py_compile src/pytorch_practice/graph/torch_gin_implementation.py` and the file compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfb1a2c420832e9ab6189a7c382038)