### PR TITLE
Add LLM implementation roadmap template

### DIFF
--- a/llm_implementation_template/01_fundamentals/CHECKLIST.md
+++ b/llm_implementation_template/01_fundamentals/CHECKLIST.md
@@ -1,0 +1,9 @@
+# Fundamentals Checklist
+
+- [ ] Prompt template versioned.
+- [ ] Chunking strategy documented (size, overlap, metadata).
+- [ ] Embedding model selected with rationale.
+- [ ] Retrieval parameters tuned (`k`, filters, rerank on/off).
+- [ ] Structured output schema implemented and tested.
+- [ ] Tool definitions include argument schema + error handling.
+- [ ] Basic latency/cost metrics captured.

--- a/llm_implementation_template/01_fundamentals/PLAN.md
+++ b/llm_implementation_template/01_fundamentals/PLAN.md
@@ -1,0 +1,17 @@
+# Stage 1: LLM App Fundamentals
+
+## Deliverable
+A minimal RAG + tool-use service that returns validated structured outputs.
+
+## Components
+1. Prompt templates (`system`, `task`, `few-shot`)
+2. Ingestion + chunking pipeline
+3. Embedding generation + vector index
+4. Retrieval layer (top-k + filters)
+5. Tool registry and function schemas
+6. Structured output schema + validator
+
+## Exit criteria
+- Retrieval precision at k measured on a small golden set.
+- Output schema validation pass rate >= target.
+- Tool calls logged with argument validation.

--- a/llm_implementation_template/02_evaluation/CHECKLIST.md
+++ b/llm_implementation_template/02_evaluation/CHECKLIST.md
@@ -1,0 +1,7 @@
+# Evaluation Checklist
+
+- [ ] Golden set covers top user intents.
+- [ ] Regression tests run in CI.
+- [ ] Pairwise report generated for major changes.
+- [ ] Failure taxonomy used consistently.
+- [ ] Business metrics dashboard includes model slices.

--- a/llm_implementation_template/02_evaluation/PLAN.md
+++ b/llm_implementation_template/02_evaluation/PLAN.md
@@ -1,0 +1,16 @@
+# Stage 2: Evaluation
+
+## Deliverable
+Automated offline and pre-release evaluation suite.
+
+## Components
+1. Golden dataset with representative scenarios
+2. Regression test runner
+3. Pairwise evaluator (baseline vs candidate)
+4. Failure taxonomy labeling
+5. Business KPI mapping
+
+## Exit criteria
+- Every release runs regression suite.
+- Pairwise evaluation required for prompt/model changes.
+- Failure labels collected for top errors.

--- a/llm_implementation_template/03_serving_ops/CHECKLIST.md
+++ b/llm_implementation_template/03_serving_ops/CHECKLIST.md
@@ -1,0 +1,8 @@
+# Serving & Ops Checklist
+
+- [ ] API contract versioned.
+- [ ] Queue retry policy includes idempotency keys.
+- [ ] Cache hit-rate monitored.
+- [ ] Request traces link retrieval/tool/model spans.
+- [ ] p95 latency and error-rate alerts configured.
+- [ ] Cost-per-request budget enforced.

--- a/llm_implementation_template/03_serving_ops/PLAN.md
+++ b/llm_implementation_template/03_serving_ops/PLAN.md
@@ -1,0 +1,17 @@
+# Stage 3: Serving and Ops
+
+## Deliverable
+Production-ready service with reliability, observability, and cost controls.
+
+## Components
+1. Public/internal API layer
+2. Async pipeline for long tasks
+3. Queue + retry strategy
+4. Caching policy (prompt, retrieval, response)
+5. Observability (logs, traces, metrics)
+6. Cost and latency budgets with alerts
+
+## Exit criteria
+- SLOs defined and monitored.
+- Alerting in place for reliability and spend spikes.
+- Deployment + rollback process documented.

--- a/llm_implementation_template/04_applied_ml_depth/CHECKLIST.md
+++ b/llm_implementation_template/04_applied_ml_depth/CHECKLIST.md
@@ -1,0 +1,7 @@
+# Applied ML Depth Checklist
+
+- [ ] Baseline established before advanced changes.
+- [ ] Reranker tested against non-reranked pipeline.
+- [ ] Embedding alternatives compared on same dataset.
+- [ ] Fine-tuning decision documented with risk/benefit.
+- [ ] Classical baseline retained for sanity checks.

--- a/llm_implementation_template/04_applied_ml_depth/PLAN.md
+++ b/llm_implementation_template/04_applied_ml_depth/PLAN.md
@@ -1,0 +1,15 @@
+# Stage 4: Applied ML Depth
+
+## Deliverable
+Measured quality improvements using ML enhancements.
+
+## Components
+1. PyTorch training/eval baseline notebooks/scripts
+2. Reranker experiment harness
+3. Embedding model bake-off workflow
+4. Fine-tuning decision rubric (when/when not)
+5. Classical baseline comparisons
+
+## Exit criteria
+- At least one improvement beats baseline on quality + cost/latency constraints.
+- Experiment tracking captures reproducible configs.

--- a/llm_implementation_template/05_optional_specialization/TRACKS.md
+++ b/llm_implementation_template/05_optional_specialization/TRACKS.md
@@ -1,0 +1,18 @@
+# Stage 5: Optional Specialization Tracks
+
+Choose one track and create a folder with your design + evaluation plan.
+
+## Suggested tracks
+- Agents
+- Multimodal
+- Recommendation/Ranking
+- Scientific AI
+- Domain-specific copilots
+
+## Track template
+For your chosen track, include:
+1. **User and workflow definition**
+2. **System architecture**
+3. **Specialized eval set**
+4. **Risks and controls**
+5. **Rollout milestones**

--- a/llm_implementation_template/README.md
+++ b/llm_implementation_template/README.md
@@ -1,0 +1,88 @@
+# LLM Implementation Template
+
+This folder is a practical template for implementing the sequence you outlined:
+
+1. **LLM app fundamentals**
+2. **Evaluation**
+3. **Serving and ops**
+4. **Applied ML depth**
+5. **Optional specialization**
+
+Each stage has a `PLAN.md` (what to build), a `CHECKLIST.md` (how to know it's done), and starter placeholders where useful.
+
+---
+
+## Structure
+
+- `01_fundamentals/`
+  - Build your first reliable retrieval + tool-using app.
+- `02_evaluation/`
+  - Add quality gates with golden sets and regression testing.
+- `03_serving_ops/`
+  - Move from notebook/demo to production operations.
+- `04_applied_ml_depth/`
+  - Add deeper ML improvements (reranking, finetuning, baselines).
+- `05_optional_specialization/`
+  - Choose one specialization track.
+- `shared/`
+  - Reusable configs, schemas, and metrics definitions.
+
+---
+
+## How each component works
+
+### 1) Fundamentals
+**Goal:** turn a model call into a dependable application.
+
+- **Prompt design:** controls behavior and output style.
+- **Embeddings:** convert text to vectors for semantic search.
+- **Chunking:** splits documents into retrievable pieces.
+- **Retrieval:** finds relevant chunks for each query.
+- **Structured outputs:** forces machine-readable responses (e.g., JSON schema).
+- **Tool use:** enables function/API calls for external actions or data.
+
+### 2) Evaluation
+**Goal:** measure quality continuously instead of manually spot-checking.
+
+- **Golden set:** trusted examples with expected answers/behavior.
+- **Regression tests:** ensure changes do not break known-good behavior.
+- **Pairwise comparison:** compare candidate systems A vs. B.
+- **Failure taxonomy:** classify errors (retrieval miss, hallucination, format failure, etc.).
+- **Business metrics:** connect model quality to outcomes (conversion, time saved, cost).
+
+### 3) Serving and Ops
+**Goal:** operate the system safely at scale.
+
+- **APIs:** stable entrypoints for product integration.
+- **Async jobs/queues:** handle long-running generation and retries.
+- **Caching:** reduce latency and cost for repeated requests.
+- **Observability:** logs, traces, and dashboards for debugging quality and performance.
+- **Cost/latency controls:** track token spend and optimize p50/p95 latency.
+
+### 4) Applied ML Depth
+**Goal:** improve ranking/quality beyond baseline RAG.
+
+- **PyTorch basics:** ability to train/evaluate simple models.
+- **Fine-tuning concepts:** adapt models with task-specific data.
+- **Rerankers:** improve top-k retrieval ordering.
+- **Embeddings iteration:** compare embedding models and chunk strategies.
+- **Classical baselines:** sanity check with non-LLM methods.
+
+### 5) Optional Specialization
+**Goal:** choose a domain where advanced depth matters.
+
+Pick one track and define:
+- target users,
+- key workflows,
+- specialized evaluation criteria,
+- unique risk controls.
+
+---
+
+## Suggested workflow
+
+1. Complete `01_fundamentals` and ship a narrow MVP.
+2. Build `02_evaluation` before broad rollout.
+3. Add `03_serving_ops` before production traffic.
+4. Use `04_applied_ml_depth` for measurable quality lifts.
+5. Expand with one `05_optional_specialization` track.

--- a/llm_implementation_template/shared/failure_taxonomy.md
+++ b/llm_implementation_template/shared/failure_taxonomy.md
@@ -1,0 +1,13 @@
+# Failure Taxonomy Template
+
+Use this list when labeling errors in evaluations and production incidents.
+
+- **Retrieval Miss**: relevant evidence exists but was not retrieved.
+- **Context Misread**: evidence was retrieved but interpreted incorrectly.
+- **Hallucination**: unsupported claim not grounded in context.
+- **Instruction Non-Compliance**: ignored system/developer/user constraints.
+- **Tool Misuse**: wrong tool selected or malformed tool arguments.
+- **Schema Violation**: structured output invalid or missing required fields.
+- **Policy/Safety Violation**: response violates policy requirements.
+- **Latency Timeout**: response exceeded SLA or hard timeout.
+- **Cost Overrun**: request exceeds token/cost budget.

--- a/llm_implementation_template/shared/metrics_template.yaml
+++ b/llm_implementation_template/shared/metrics_template.yaml
@@ -1,0 +1,18 @@
+# Shared metrics catalog for all stages
+quality:
+  - answer_correctness
+  - groundedness
+  - schema_validity
+reliability:
+  - failure_rate
+  - timeout_rate
+performance:
+  - p50_latency_ms
+  - p95_latency_ms
+cost:
+  - avg_input_tokens
+  - avg_output_tokens
+  - cost_per_request_usd
+business:
+  - task_success_rate
+  - user_resolution_rate


### PR DESCRIPTION
### Motivation
- Provide a practical, staged scaffold that turns the proposed LLM learning/build sequence into an executable implementation plan with clear deliverables and exit criteria. 
- Make it easy to onboard teams to a repeatable development path covering fundamentals, evaluation, serving/ops, applied ML depth, and an optional specialization. 
- Centralize shared artifacts (metrics, failure taxonomy) to ensure consistent evaluation and operational observability across stages.

### Description
- Add `llm_implementation_template/` with per-stage folders (`01_fundamentals`, `02_evaluation`, `03_serving_ops`, `04_applied_ml_depth`, `05_optional_specialization`) each containing `PLAN.md` and/or `CHECKLIST.md` outlining components and exit criteria. 
- Add `llm_implementation_template/README.md` that explains the purpose, component responsibilities, and a suggested workflow for progressing through stages. 
- Add `llm_implementation_template/shared/metrics_template.yaml` as a shared metrics catalog and `llm_implementation_template/shared/failure_taxonomy.md` as a failure labeling template to standardize evaluation and incident classification. 
- Add `05_optional_specialization/TRACKS.md` to guide choosing and scoping a specialization track (agents, multimodal, ranking, scientific AI, domain copilots).

### Testing
- Verified presence of created files with `find llm_implementation_template -maxdepth 3 -type f | sort` and confirmed the listing matched the intended structure. 
- Previewed the top-level README contents with `nl -ba llm_implementation_template/README.md` to ensure documentation was written as expected. 
- This is a documentation-only change and required no unit or integration tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d3f46f8638832e9e473120642b9b36)