### PR TITLE
Add chemistry/materials-focused PyTorch exercises (62–65)

### DIFF
--- a/pytorchlings/EXERCISES.md
+++ b/pytorchlings/EXERCISES.md
@@ -67,3 +67,7 @@
 | 59 | PyG | Diffusion-based GNN (APPNP) | `exercises/59_diffusion_gnn/appnp_diffusion.py` | `solutions/59_appnp_diffusion.py` |
 | 60 | PyTorch + Optuna | Hyperparameter tuning for MLP classification | `exercises/60_optuna_tuning/optuna_pytorch_mlp.py` | `solutions/60_optuna_pytorch_mlp.py` |
 | 61 | Scikit-learn + Optuna | Tune RandomForest baseline with CV | `exercises/61_optuna_baselines/optuna_sklearn_baseline.py` | `solutions/61_optuna_sklearn_baseline.py` |
+| 62 | PyTorch | Masked-token transformer for toy chemistry strings | `exercises/62_masked_modeling_transformer/masked_token_model.py` | `solutions/62_masked_modeling_transformer.py` |
+| 63 | PyTorch | Property-conditioned sequence generation (GRU) | `exercises/63_conditional_generation/property_conditioned_generation.py` | `solutions/63_property_conditioned_generation.py` |
+| 64 | PyTorch | Hill-climb eval loop for scientific MAE optimization | `exercises/64_hillclimb_evals/experiment_hillclimb.py` | `solutions/64_eval_hillclimb.py` |
+| 65 | PyTorch | Slice-based scientific error analysis + reporting | `exercises/65_science_error_analysis/scientific_error_analysis.py` | `solutions/65_scientific_error_analysis.py` |

--- a/pytorchlings/README.md
+++ b/pytorchlings/README.md
@@ -22,6 +22,7 @@ A rustlings-style practice track for **PyTorch** and **PyTorch Geometric (PyG)**
 - Complete 38-47 for comprehensive PyTorch engineering workflows (losses, hooks, initialization, accumulation, AMP, compile, TorchScript, packed sequences).
 - Continue 48-59 for advanced graph architecture coverage (GCN, GAT, GraphSAGE, GIN, spectral, pooling, hyperbolic, dynamic, R-GCN, graph transformer, graph autoencoder, diffusion).
 - Add 60-61 for Optuna-based hyperparameter optimization (PyTorch MLP + scikit-learn baseline tuning).
+- Add 62-65 for chemistry-oriented generative modeling, hill-climbing evals, and slice-based scientific error analysis.
 
 ## Quick check command
 
@@ -78,3 +79,12 @@ Exercises 60-61 introduce Optuna workflows so learners can practice search-space
 - Intermediate metric reporting + pruning hooks
 - TPE and random samplers with fixed seeds
 - Non-neural baseline tuning with scikit-learn cross-validation
+## Chemistry + materials interview-focused extension
+
+Exercises 62-65 target role-relevant fundamentals for generative science workflows:
+
+- Masked-token transformer pretraining on toy chemistry strings
+- Property-conditioned sequence generation
+- Hill-climb eval loops for iterative model improvement
+- Slice-wise scientific error analysis + markdown reporting for collaboration
+

--- a/pytorchlings/exercises/62_masked_modeling_transformer/masked_token_model.py
+++ b/pytorchlings/exercises/62_masked_modeling_transformer/masked_token_model.py
@@ -1,0 +1,85 @@
+"""Exercise 62: masked-token transformer pretraining on toy chemistry strings.
+
+Goal:
+- practice transformer modeling
+- implement masked-language-model style loss
+- reason about tokenization + padding + masking
+"""
+from __future__ import annotations
+
+import random
+
+import torch
+from torch import nn
+
+TOKENS = ["<pad>", "<mask>", "C", "O", "N", "H", "=", "#", "(", ")"]
+VOCAB = {t: i for i, t in enumerate(TOKENS)}
+
+
+def encode(seq: str, max_len: int = 12) -> torch.Tensor:
+    ids = [VOCAB[c] for c in seq]
+    ids = ids[:max_len] + [VOCAB["<pad>"]] * max(0, max_len - len(ids))
+    return torch.tensor(ids, dtype=torch.long)
+
+
+def mask_inputs(batch_ids: torch.Tensor, mask_prob: float = 0.2) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return (masked_ids, labels).
+
+    labels should hold original token id where we mask and -100 elsewhere so
+    CrossEntropyLoss(ignore_index=-100) works.
+    """
+    masked = batch_ids.clone()
+    labels = torch.full_like(batch_ids, fill_value=-100)
+    for i in range(batch_ids.size(0)):
+        for j in range(batch_ids.size(1)):
+            tok = int(batch_ids[i, j].item())
+            if tok == VOCAB["<pad>"]:
+                continue
+            # TODO: sample mask event with probability mask_prob.
+            # TODO: if masked, set labels[i, j] to original token and masked[i, j] to <mask> token id.
+    return masked, labels
+
+
+class MaskedChemTransformer(nn.Module):
+    def __init__(self, d_model: int = 32, nhead: int = 4, max_len: int = 12):
+        super().__init__()
+        self.tok_emb = nn.Embedding(len(TOKENS), d_model)
+        self.pos_emb = nn.Embedding(max_len, d_model)
+        self.encoder = nn.TransformerEncoder(
+            nn.TransformerEncoderLayer(d_model=d_model, nhead=nhead, batch_first=True), num_layers=2
+        )
+        self.out = nn.Linear(d_model, len(TOKENS))
+
+    def forward(self, ids: torch.Tensor) -> torch.Tensor:
+        pos = torch.arange(ids.size(1), device=ids.device).unsqueeze(0)
+        x = self.tok_emb(ids) + self.pos_emb(pos)
+        h = self.encoder(x)
+        return self.out(h)
+
+
+def run_step(model: nn.Module, optimizer: torch.optim.Optimizer, batch: torch.Tensor) -> float:
+    masked, labels = mask_inputs(batch)
+    logits = model(masked)
+    # TODO: compute token prediction loss with CrossEntropyLoss(ignore_index=-100).
+    # hint: logits shape is [B, T, V]; flatten to [B*T, V], labels -> [B*T].
+    loss = torch.tensor(0.0)
+
+    optimizer.zero_grad()
+    loss.backward()
+    optimizer.step()
+    return float(loss.item())
+
+
+if __name__ == "__main__":
+    random.seed(0)
+    torch.manual_seed(0)
+
+    sequences = ["C=O", "CCO", "N#N", "C(OH)C", "COC", "CCN"]
+    batch = torch.stack([encode(s) for s in sequences], dim=0)
+
+    model = MaskedChemTransformer()
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    for step in range(3):
+        loss = run_step(model, opt, batch)
+        print(f"step={step} loss={loss:.4f}")

--- a/pytorchlings/exercises/63_conditional_generation/property_conditioned_generation.py
+++ b/pytorchlings/exercises/63_conditional_generation/property_conditioned_generation.py
@@ -1,0 +1,64 @@
+"""Exercise 63: property-conditioned generation with a tiny GRU decoder.
+
+Goal:
+- condition generation on a target scalar property (toy solubility)
+- wire embedding + recurrent decoder + teacher forcing loss
+"""
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+TOKENS = ["<pad>", "<bos>", "<eos>", "C", "O", "N"]
+VOCAB = {t: i for i, t in enumerate(TOKENS)}
+
+
+def encode(seq: str, max_len: int = 10) -> torch.Tensor:
+    ids = [VOCAB["<bos>"]] + [VOCAB[c] for c in seq] + [VOCAB["<eos>"]]
+    ids = ids[:max_len] + [VOCAB["<pad>"]] * max(0, max_len - len(ids))
+    return torch.tensor(ids, dtype=torch.long)
+
+
+class ConditionalGenerator(nn.Module):
+    def __init__(self, d_model: int = 32):
+        super().__init__()
+        self.token_emb = nn.Embedding(len(TOKENS), d_model)
+        self.prop_proj = nn.Linear(1, d_model)
+        self.rnn = nn.GRU(input_size=d_model, hidden_size=d_model, batch_first=True)
+        self.head = nn.Linear(d_model, len(TOKENS))
+
+    def forward(self, ids: torch.Tensor, prop: torch.Tensor) -> torch.Tensor:
+        tok = self.token_emb(ids)
+        # TODO: project scalar prop [B, 1] into d_model and broadcast over sequence length.
+        cond = torch.zeros_like(tok)
+        # TODO: add conditioning vector to token embeddings before feeding GRU.
+        h, _ = self.rnn(tok)
+        return self.head(h)
+
+
+def teacher_forcing_loss(model: nn.Module, ids: torch.Tensor, prop: torch.Tensor) -> torch.Tensor:
+    """Next-token loss using shifted inputs and targets."""
+    x_in = ids[:, :-1]
+    y_target = ids[:, 1:]
+    logits = model(x_in, prop)
+    # TODO: compute CE loss ignoring pad tokens.
+    return torch.tensor(0.0)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+
+    seqs = ["CO", "CCO", "NCO", "CCN"]
+    # toy property: higher value for more oxygen atoms
+    props = torch.tensor([[1.0], [0.7], [0.9], [0.3]])
+    ids = torch.stack([encode(s) for s in seqs])
+
+    model = ConditionalGenerator(d_model=24)
+    opt = torch.optim.Adam(model.parameters(), lr=2e-3)
+
+    for step in range(5):
+        loss = teacher_forcing_loss(model, ids, props)
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        print(f"step={step} loss={float(loss.item()):.4f}")

--- a/pytorchlings/exercises/64_hillclimb_evals/experiment_hillclimb.py
+++ b/pytorchlings/exercises/64_hillclimb_evals/experiment_hillclimb.py
@@ -1,0 +1,77 @@
+"""Exercise 64: hill-climb evaluation loop for scientific modeling.
+
+Goal:
+- run iterative experiments
+- keep best checkpoint by domain-relevant metric
+- log compact experiment summaries for collaborators
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import torch
+from torch import nn
+
+
+@dataclasses.dataclass
+class TrialResult:
+    hidden_dim: int
+    lr: float
+    val_mae: float
+
+
+def make_dataset(n: int = 512) -> tuple[torch.Tensor, torch.Tensor]:
+    g = torch.Generator().manual_seed(12)
+    x = torch.randn(n, 6, generator=g)
+    # toy target: proxy for material property
+    y = (0.6 * x[:, 0] - 0.3 * x[:, 1] ** 2 + 0.4 * x[:, 2] * x[:, 3]).unsqueeze(1)
+    y = y + 0.05 * torch.randn_like(y, generator=g)
+    return x, y
+
+
+def train_one_trial(hidden_dim: int, lr: float, x_train: torch.Tensor, y_train: torch.Tensor, x_val: torch.Tensor, y_val: torch.Tensor) -> TrialResult:
+    model = nn.Sequential(nn.Linear(6, hidden_dim), nn.ReLU(), nn.Linear(hidden_dim, 1))
+    opt = torch.optim.Adam(model.parameters(), lr=lr)
+    loss_fn = nn.MSELoss()
+
+    for _ in range(80):
+        pred = model(x_train)
+        loss = loss_fn(pred, y_train)
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+
+    with torch.no_grad():
+        val_mae = torch.mean(torch.abs(model(x_val) - y_val)).item()
+    return TrialResult(hidden_dim=hidden_dim, lr=lr, val_mae=float(val_mae))
+
+
+def hillclimb_search() -> tuple[TrialResult, list[TrialResult]]:
+    x, y = make_dataset()
+    x_train, y_train = x[:400], y[:400]
+    x_val, y_val = x[400:], y[400:]
+
+    # TODO: start from this seed config.
+    current = TrialResult(hidden_dim=16, lr=2e-3, val_mae=1e9)
+    history: list[TrialResult] = []
+
+    # TODO: implement a 4-round hill-climb proposal loop.
+    # Proposal rule suggestion:
+    #   hidden_dim candidates: [current.hidden_dim, current.hidden_dim * 2]
+    #   lr candidates: [current.lr, current.lr * 0.5, current.lr * 2.0]
+    # For each round, evaluate all combinations and keep the best candidate as `current`.
+
+    return current, history
+
+
+def summarize(history: list[TrialResult]) -> str:
+    lines = ["round,hidden_dim,lr,val_mae"]
+    for i, h in enumerate(history):
+        lines.append(f"{i},{h.hidden_dim},{h.lr:.5f},{h.val_mae:.6f}")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    best, hist = hillclimb_search()
+    print(summarize(hist))
+    print("best:", best)

--- a/pytorchlings/exercises/65_science_error_analysis/scientific_error_analysis.py
+++ b/pytorchlings/exercises/65_science_error_analysis/scientific_error_analysis.py
@@ -1,0 +1,58 @@
+"""Exercise 65: scientific error analysis for model communication.
+
+Goal:
+- compute slice metrics by chemistry-like regime
+- turn raw outputs into concise, shareable diagnostics
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class SliceReport:
+    name: str
+    count: int
+    mae: float
+
+
+def make_predictions() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Return (y_true, y_pred, oxygen_fraction)."""
+    y_true = torch.tensor([0.10, 0.20, 0.18, 0.32, 0.28, 0.41, 0.37, 0.52, 0.50, 0.62])
+    y_pred = torch.tensor([0.12, 0.25, 0.16, 0.30, 0.22, 0.44, 0.40, 0.49, 0.57, 0.66])
+    oxygen_fraction = torch.tensor([0.0, 0.2, 0.1, 0.3, 0.2, 0.5, 0.6, 0.7, 0.8, 0.9])
+    return y_true, y_pred, oxygen_fraction
+
+
+def mae(y_true: torch.Tensor, y_pred: torch.Tensor) -> float:
+    # TODO: implement mean absolute error.
+    return 0.0
+
+
+def build_slice_reports(y_true: torch.Tensor, y_pred: torch.Tensor, oxygen_fraction: torch.Tensor) -> list[SliceReport]:
+    """Create low/mid/high oxygen slice reports.
+
+    low:  oxygen_fraction < 0.3
+    mid:  0.3 <= oxygen_fraction < 0.7
+    high: oxygen_fraction >= 0.7
+    """
+    reports: list[SliceReport] = []
+    # TODO: create boolean masks for each slice.
+    # TODO: compute count + MAE per slice and append SliceReport entries.
+    return reports
+
+
+def make_markdown_summary(reports: list[SliceReport], overall_mae: float) -> str:
+    lines = ["# Validation Error Summary", "", f"Overall MAE: {overall_mae:.4f}", "", "| Slice | Count | MAE |", "|---|---:|---:|"]
+    for r in reports:
+        lines.append(f"| {r.name} | {r.count} | {r.mae:.4f} |")
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    y_true, y_pred, oxygen_fraction = make_predictions()
+    overall = mae(y_true, y_pred)
+    reports = build_slice_reports(y_true, y_pred, oxygen_fraction)
+    print(make_markdown_summary(reports, overall))

--- a/pytorchlings/solutions/62_masked_modeling_transformer.py
+++ b/pytorchlings/solutions/62_masked_modeling_transformer.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import random
+
+import torch
+from torch import nn
+
+TOKENS = ["<pad>", "<mask>", "C", "O", "N", "H", "=", "#", "(", ")"]
+VOCAB = {t: i for i, t in enumerate(TOKENS)}
+
+
+def encode(seq: str, max_len: int = 12) -> torch.Tensor:
+    ids = [VOCAB[c] for c in seq]
+    ids = ids[:max_len] + [VOCAB["<pad>"]] * max(0, max_len - len(ids))
+    return torch.tensor(ids, dtype=torch.long)
+
+
+def mask_inputs(batch_ids: torch.Tensor, mask_prob: float = 0.2) -> tuple[torch.Tensor, torch.Tensor]:
+    masked = batch_ids.clone()
+    labels = torch.full_like(batch_ids, fill_value=-100)
+    for i in range(batch_ids.size(0)):
+        for j in range(batch_ids.size(1)):
+            tok = int(batch_ids[i, j].item())
+            if tok == VOCAB["<pad>"]:
+                continue
+            if random.random() < mask_prob:
+                labels[i, j] = tok
+                masked[i, j] = VOCAB["<mask>"]
+    return masked, labels
+
+
+class MaskedChemTransformer(nn.Module):
+    def __init__(self, d_model: int = 32, nhead: int = 4, max_len: int = 12):
+        super().__init__()
+        self.tok_emb = nn.Embedding(len(TOKENS), d_model)
+        self.pos_emb = nn.Embedding(max_len, d_model)
+        self.encoder = nn.TransformerEncoder(
+            nn.TransformerEncoderLayer(d_model=d_model, nhead=nhead, batch_first=True), num_layers=2
+        )
+        self.out = nn.Linear(d_model, len(TOKENS))
+
+    def forward(self, ids: torch.Tensor) -> torch.Tensor:
+        pos = torch.arange(ids.size(1), device=ids.device).unsqueeze(0)
+        x = self.tok_emb(ids) + self.pos_emb(pos)
+        h = self.encoder(x)
+        return self.out(h)
+
+
+def run_step(model: nn.Module, optimizer: torch.optim.Optimizer, batch: torch.Tensor) -> float:
+    masked, labels = mask_inputs(batch)
+    logits = model(masked)
+    loss_fn = nn.CrossEntropyLoss(ignore_index=-100)
+    loss = loss_fn(logits.view(-1, logits.size(-1)), labels.view(-1))
+
+    optimizer.zero_grad()
+    loss.backward()
+    optimizer.step()
+    return float(loss.item())

--- a/pytorchlings/solutions/63_property_conditioned_generation.py
+++ b/pytorchlings/solutions/63_property_conditioned_generation.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+TOKENS = ["<pad>", "<bos>", "<eos>", "C", "O", "N"]
+VOCAB = {t: i for i, t in enumerate(TOKENS)}
+
+
+def encode(seq: str, max_len: int = 10) -> torch.Tensor:
+    ids = [VOCAB["<bos>"]] + [VOCAB[c] for c in seq] + [VOCAB["<eos>"]]
+    ids = ids[:max_len] + [VOCAB["<pad>"]] * max(0, max_len - len(ids))
+    return torch.tensor(ids, dtype=torch.long)
+
+
+class ConditionalGenerator(nn.Module):
+    def __init__(self, d_model: int = 32):
+        super().__init__()
+        self.token_emb = nn.Embedding(len(TOKENS), d_model)
+        self.prop_proj = nn.Linear(1, d_model)
+        self.rnn = nn.GRU(input_size=d_model, hidden_size=d_model, batch_first=True)
+        self.head = nn.Linear(d_model, len(TOKENS))
+
+    def forward(self, ids: torch.Tensor, prop: torch.Tensor) -> torch.Tensor:
+        tok = self.token_emb(ids)
+        cond = self.prop_proj(prop).unsqueeze(1).expand(-1, ids.size(1), -1)
+        h, _ = self.rnn(tok + cond)
+        return self.head(h)
+
+
+def teacher_forcing_loss(model: nn.Module, ids: torch.Tensor, prop: torch.Tensor) -> torch.Tensor:
+    x_in = ids[:, :-1]
+    y_target = ids[:, 1:]
+    logits = model(x_in, prop)
+    return nn.CrossEntropyLoss(ignore_index=VOCAB["<pad>"])(logits.reshape(-1, logits.size(-1)), y_target.reshape(-1))

--- a/pytorchlings/solutions/64_eval_hillclimb.py
+++ b/pytorchlings/solutions/64_eval_hillclimb.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import dataclasses
+
+import torch
+from torch import nn
+
+
+@dataclasses.dataclass
+class TrialResult:
+    hidden_dim: int
+    lr: float
+    val_mae: float
+
+
+def make_dataset(n: int = 512) -> tuple[torch.Tensor, torch.Tensor]:
+    g = torch.Generator().manual_seed(12)
+    x = torch.randn(n, 6, generator=g)
+    y = (0.6 * x[:, 0] - 0.3 * x[:, 1] ** 2 + 0.4 * x[:, 2] * x[:, 3]).unsqueeze(1)
+    y = y + 0.05 * torch.randn_like(y, generator=g)
+    return x, y
+
+
+def train_one_trial(hidden_dim: int, lr: float, x_train: torch.Tensor, y_train: torch.Tensor, x_val: torch.Tensor, y_val: torch.Tensor) -> TrialResult:
+    model = nn.Sequential(nn.Linear(6, hidden_dim), nn.ReLU(), nn.Linear(hidden_dim, 1))
+    opt = torch.optim.Adam(model.parameters(), lr=lr)
+    loss_fn = nn.MSELoss()
+
+    for _ in range(80):
+        pred = model(x_train)
+        loss = loss_fn(pred, y_train)
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+
+    with torch.no_grad():
+        val_mae = torch.mean(torch.abs(model(x_val) - y_val)).item()
+    return TrialResult(hidden_dim=hidden_dim, lr=lr, val_mae=float(val_mae))
+
+
+def hillclimb_search() -> tuple[TrialResult, list[TrialResult]]:
+    x, y = make_dataset()
+    x_train, y_train = x[:400], y[:400]
+    x_val, y_val = x[400:], y[400:]
+
+    current = TrialResult(hidden_dim=16, lr=2e-3, val_mae=1e9)
+    history: list[TrialResult] = []
+
+    for _ in range(4):
+        best_round: TrialResult | None = None
+        dim_candidates = [current.hidden_dim, current.hidden_dim * 2]
+        lr_candidates = [current.lr, current.lr * 0.5, current.lr * 2.0]
+
+        for hd in dim_candidates:
+            for lr in lr_candidates:
+                candidate = train_one_trial(hd, lr, x_train, y_train, x_val, y_val)
+                if best_round is None or candidate.val_mae < best_round.val_mae:
+                    best_round = candidate
+
+        assert best_round is not None
+        current = best_round
+        history.append(current)
+
+    return current, history

--- a/pytorchlings/solutions/65_scientific_error_analysis.py
+++ b/pytorchlings/solutions/65_scientific_error_analysis.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class SliceReport:
+    name: str
+    count: int
+    mae: float
+
+
+def make_predictions() -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    y_true = torch.tensor([0.10, 0.20, 0.18, 0.32, 0.28, 0.41, 0.37, 0.52, 0.50, 0.62])
+    y_pred = torch.tensor([0.12, 0.25, 0.16, 0.30, 0.22, 0.44, 0.40, 0.49, 0.57, 0.66])
+    oxygen_fraction = torch.tensor([0.0, 0.2, 0.1, 0.3, 0.2, 0.5, 0.6, 0.7, 0.8, 0.9])
+    return y_true, y_pred, oxygen_fraction
+
+
+def mae(y_true: torch.Tensor, y_pred: torch.Tensor) -> float:
+    return float(torch.mean(torch.abs(y_true - y_pred)).item())
+
+
+def build_slice_reports(y_true: torch.Tensor, y_pred: torch.Tensor, oxygen_fraction: torch.Tensor) -> list[SliceReport]:
+    reports: list[SliceReport] = []
+
+    masks = {
+        "low oxygen": oxygen_fraction < 0.3,
+        "mid oxygen": (oxygen_fraction >= 0.3) & (oxygen_fraction < 0.7),
+        "high oxygen": oxygen_fraction >= 0.7,
+    }
+
+    for name, mask in masks.items():
+        y_t = y_true[mask]
+        y_p = y_pred[mask]
+        reports.append(SliceReport(name=name, count=int(mask.sum().item()), mae=mae(y_t, y_p)))
+    return reports


### PR DESCRIPTION
### Motivation
- Provide interview- and role-focused practice for generative chemistry/materials workflows by adding small, focused PyTorch exercises to the `pytorchlings` track. 
- Cover fundamentals relevant to the role: masked-token pretraining, property-conditioned generation, iterative hill-climb evals, and slice-wise scientific error analysis.

### Description
- Added four new exercise scaffolds under `pytorchlings/exercises`: `62_masked_modeling_transformer/masked_token_model.py`, `63_conditional_generation/property_conditioned_generation.py`, `64_hillclimb_evals/experiment_hillclimb.py`, and `65_science_error_analysis/scientific_error_analysis.py`, each containing `TODO` prompts for learners. 
- Added matching solution files under `pytorchlings/solutions`: `solutions/62_masked_modeling_transformer.py`, `solutions/63_property_conditioned_generation.py`, `solutions/64_eval_hillclimb.py`, and `solutions/65_scientific_error_analysis.py` with reference implementations. 
- Updated the exercise index table `pytorchlings/EXERCISES.md` to include entries `62`–`65` and extended `pytorchlings/README.md` with a short “Chemistry + materials interview-focused extension” note and progression suggestion.

### Testing
- Ran `python -m compileall` on the new exercise and solution files (`pytorchlings/exercises/62_*`, `pytorchlings/exercises/63_*`, `pytorchlings/exercises/64_*`, `pytorchlings/exercises/65_*` and the corresponding `pytorchlings/solutions/*`) to ensure they are syntactically valid, and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7625caa0c832e9ca053acdcdf47cb)