### PR TITLE
Add BioAI Research Engineer Interview Exercise Pack to README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -30,3 +30,66 @@ If you need to build the original geometry binary, use:
 ```bash
 g++ -I lib/eigen-3.4.0/ -I lib/ cxx/geometry_functions.cxx main.cxx -o ./main
 ```
+
+## Research Engineer Interview Exercise Pack (BioAI)
+
+The following exercises are designed for hiring/recruiting loops for a Research Engineer role focused on AI for drug discovery.
+
+### 1) Neural Network Fundamentals (take-home, 60–90 min)
+
+- Build a small neural network to predict a binary property from sequence-like inputs.
+- Compare at least two architectures (for example: MLP vs. 1D CNN or a tiny Transformer).
+- Report train/validation metrics, overfitting behavior, and one optimization you attempted.
+
+### 2) Distributed Training Systems (practical, 90 min)
+
+- Start from a single-GPU training script and describe/adapt it for multi-GPU training.
+- Identify bottlenecks (data loading, communication overhead, memory) and mitigation strategies.
+- Discuss tradeoffs between data parallel and sharded approaches.
+
+### 3) Profiling and Optimization (debug session, 60 min)
+
+- Profile a deliberately inefficient training script.
+- Identify the top bottlenecks and implement (or propose) fixes.
+- Show before/after runtime or memory measurements.
+
+### 4) BioAI Problem Framing (whiteboard, 45 min)
+
+Prompt: design an ML workflow to prioritize antibody candidates for a hard-to-drug target.
+
+Candidate should cover:
+- data sources (sequence, structure, assay)
+- objective definition (affinity, specificity, developability)
+- evaluation plan (offline metrics + wet-lab handoff)
+- uncertainty and failure-mode handling
+
+### 5) Foundation Model Design Case (system design, 60 min)
+
+Prompt: design a biology/disease foundation model to improve target elucidation and patient stratification.
+
+Candidate should address:
+- multimodal inputs and pretraining objectives
+- fine-tuning strategy for downstream tasks
+- interpretability, bias, and deployment considerations
+
+### 6) Code Quality + Collaboration (pairing, 45 min)
+
+- Refactor a small research code sample for clarity.
+- Add basic tests and concise documentation.
+- Explain decisions while pairing with the interviewer.
+
+### 7) Research Communication (presentation, 20–30 min)
+
+- Present one prior project/public repo contribution.
+- Explain approach, tradeoffs, failures, and next steps.
+
+### Suggested scoring rubric (1–4 each)
+
+- ML fundamentals
+- Scaling/systems engineering
+- Optimization/debugging
+- BioAI reasoning
+- Code quality
+- Collaboration and communication
+
+A strong overall signal is typically 3+ in most categories with at least one area of clear excellence.


### PR DESCRIPTION
### Motivation
- Centralize a set of standardized interview exercises for a Research Engineer role focused on AI for drug discovery directly in the repository documentation.
- Provide a concise, consistent set of practical tasks and a scoring rubric to support hiring and evaluation across modeling, systems, optimization, and communication skills.

### Description
- Append a `Research Engineer Interview Exercise Pack (BioAI)` section to `README.txt` that lists seven exercises covering neural network fundamentals, distributed training, profiling and optimization, problem framing, foundation model design, code quality/collaboration, and research communication.
- Add a suggested scoring rubric with six criteria to guide assessments and indicate expected signal thresholds.
- This change is documentation-only and does not modify source code or build scripts.

### Testing
- No automated tests were modified or required for this documentation-only change.
- No automated test runs were executed as part of this update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e68c5f64832e8ee6e685b905531c)