### PR TITLE
Add interview-focused PyTorch exercise set (66–73)

### DIFF
--- a/pytorchlings/EXERCISES.md
+++ b/pytorchlings/EXERCISES.md
@@ -71,3 +71,12 @@
 | 63 | PyTorch | Property-conditioned sequence generation (GRU) | `exercises/63_conditional_generation/property_conditioned_generation.py` | `solutions/63_property_conditioned_generation.py` |
 | 64 | PyTorch | Hill-climb eval loop for scientific MAE optimization | `exercises/64_hillclimb_evals/experiment_hillclimb.py` | `solutions/64_eval_hillclimb.py` |
 | 65 | PyTorch | Slice-based scientific error analysis + reporting | `exercises/65_science_error_analysis/scientific_error_analysis.py` | `solutions/65_scientific_error_analysis.py` |
+
+| 66 | PyTorch | Math-for-ML drills (projections, Jacobians, NLL) | `exercises/66_math_for_ml/matrix_calculus_drills.py` | `N/A (exercise scaffold)` |
+| 67 | PyTorch | Paper-baseline implementation from scratch | `exercises/67_pytorch_paper_baseline/paper_baseline_training.py` | `N/A (exercise scaffold)` |
+| 68 | PyTorch | Accelerator-native mindset (`compile`, `vmap`, functional params) | `exercises/68_accelerator_native_thinking/jit_vmap_pytree_mindset.py` | `N/A (exercise scaffold)` |
+| 69 | PyTorch + RDKit + PyG | Molecule preprocessing pipeline from SMILES | `exercises/69_rdkit_pyg_pipeline/rdkit_to_pyg_dataset.py` | `N/A (exercise scaffold)` |
+| 70 | PyG | GCN/GIN/GAT comparison scaffold | `exercises/70_gnn_model_comparison/gcn_gin_gat_benchmark.py` | `N/A (exercise scaffold)` |
+| 71 | PyTorch | Protein-ligand graph-only vs geometry-aware comparison | `exercises/71_protein_ligand_geometry/protein_ligand_graph_vs_geometry.py` | `N/A (exercise scaffold)` |
+| 72 | PyTorch | Reproducible training framework scaffold | `exercises/72_research_framework/reproducible_training_stack.py` | `N/A (exercise scaffold)` |
+| 73 | PyTorch | Ablation + failure-analysis report workflow | `exercises/73_ablation_failure_analysis/ablation_and_failure_report.py` | `N/A (exercise scaffold)` |

--- a/pytorchlings/README.md
+++ b/pytorchlings/README.md
@@ -23,6 +23,7 @@ A rustlings-style practice track for **PyTorch** and **PyTorch Geometric (PyG)**
 - Continue 48-59 for advanced graph architecture coverage (GCN, GAT, GraphSAGE, GIN, spectral, pooling, hyperbolic, dynamic, R-GCN, graph transformer, graph autoencoder, diffusion).
 - Add 60-61 for Optuna-based hyperparameter optimization (PyTorch MLP + scikit-learn baseline tuning).
 - Add 62-65 for chemistry-oriented generative modeling, hill-climbing evals, and slice-based scientific error analysis.
+- Add 66-73 for interview-focused research practice: math refresh drills, from-scratch baselines, accelerator-native patterns, RDKit/PyG pipelines, graph-vs-geometry modeling, reproducible training stacks, and ablation reporting.
 
 ## Quick check command
 

--- a/pytorchlings/exercises/66_math_for_ml/matrix_calculus_drills.py
+++ b/pytorchlings/exercises/66_math_for_ml/matrix_calculus_drills.py
@@ -1,0 +1,71 @@
+"""Exercise 66: math refresh drills used directly in ML training code.
+
+Goal:
+- practice vectorized linear algebra primitives (SVD, projection, quadratic form)
+- compute gradients/Jacobians/Hessians with autograd
+- implement a negative log-likelihood objective
+"""
+
+import torch
+
+
+def projection_matrix(basis: torch.Tensor) -> torch.Tensor:
+    """Return projection matrix P = Q Q^T for full-rank basis columns.
+
+    basis: [d, k] matrix with k <= d.
+    """
+    # TODO: use QR decomposition to get an orthonormal Q, then return Q @ Q.T
+    q, _ = torch.linalg.qr(basis)
+    return q @ q.T
+
+
+def quadratic_form(x: torch.Tensor, a: torch.Tensor) -> torch.Tensor:
+    """Compute scalar x^T A x for x:[d], A:[d,d]."""
+    # TODO: return a scalar tensor representing x^T A x
+    return x @ a @ x
+
+
+def gaussian_nll(x: torch.Tensor, mu: torch.Tensor, log_var: torch.Tensor) -> torch.Tensor:
+    """Diagonal Gaussian negative log-likelihood (mean over batch)."""
+    # TODO: implement NLL using exp(log_var) as variance
+    var = torch.exp(log_var)
+    nll = 0.5 * (torch.log(2 * torch.pi * var) + (x - mu).pow(2) / var)
+    return nll.mean()
+
+
+def jacobian_of_linear_map(w: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+    """Compute Jacobian of f(x)=Wx wrt x using autograd.functional.jacobian."""
+
+    def fn(inp: torch.Tensor) -> torch.Tensor:
+        return w @ inp
+
+    # TODO: compute and return Jacobian J with shape [out_dim, in_dim]
+    return torch.autograd.functional.jacobian(fn, x)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+
+    basis = torch.randn(5, 2)
+    p = projection_matrix(basis)
+    assert p.shape == (5, 5)
+
+    x = torch.randn(4, requires_grad=True)
+    a = torch.randn(4, 4)
+    a = 0.5 * (a + a.T)
+    q = quadratic_form(x, a)
+    q.backward()
+    assert x.grad is not None
+
+    xb = torch.randn(8, 3)
+    mu = torch.randn(8, 3, requires_grad=True)
+    lv = torch.zeros(8, 3, requires_grad=True)
+    loss = gaussian_nll(xb, mu, lv)
+    loss.backward()
+    assert mu.grad is not None and lv.grad is not None
+
+    w = torch.randn(3, 4)
+    xin = torch.randn(4)
+    j = jacobian_of_linear_map(w, xin)
+    assert j.shape == (3, 4)
+    print("exercise 66 smoke check passed")

--- a/pytorchlings/exercises/67_pytorch_paper_baseline/paper_baseline_training.py
+++ b/pytorchlings/exercises/67_pytorch_paper_baseline/paper_baseline_training.py
@@ -1,0 +1,101 @@
+"""Exercise 67: implement a paper baseline without high-level wrappers.
+
+Focus:
+- explicit model definition
+- explicit train/eval loops
+- gradient/debug instrumentation
+- basic ablation hook points
+"""
+
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+
+class BaselineMLP(nn.Module):
+    def __init__(self, in_dim: int, hidden: int, out_dim: int, dropout: float = 0.1):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(in_dim, hidden),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(hidden, out_dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+@dataclass
+class TrainStats:
+    train_loss: float
+    val_loss: float
+    val_acc: float
+
+
+def evaluate(model: nn.Module, loader: DataLoader, criterion: nn.Module) -> tuple[float, float]:
+    model.eval()
+    total_loss, total_correct, total = 0.0, 0, 0
+
+    with torch.no_grad():
+        for x, y in loader:
+            logits = model(x)
+            loss = criterion(logits, y)
+            total_loss += loss.item() * x.size(0)
+            total_correct += (logits.argmax(dim=1) == y).sum().item()
+            total += x.size(0)
+
+    return total_loss / max(total, 1), total_correct / max(total, 1)
+
+
+def train_one_epoch(model: nn.Module, loader: DataLoader, optimizer, criterion: nn.Module) -> float:
+    model.train()
+    running, n = 0.0, 0
+
+    for x, y in loader:
+        optimizer.zero_grad()
+        logits = model(x)
+        loss = criterion(logits, y)
+
+        # TODO: add optional gradient norm logging before optimizer.step()
+        loss.backward()
+        optimizer.step()
+
+        running += loss.item() * x.size(0)
+        n += x.size(0)
+
+    return running / max(n, 1)
+
+
+def run_baseline(
+    epochs: int = 5,
+    lr: float = 1e-2,
+    weight_decay: float = 0.0,
+) -> TrainStats:
+    torch.manual_seed(7)
+    x = torch.randn(512, 16)
+    y = torch.randint(0, 4, (512,))
+
+    train_ds = TensorDataset(x[:400], y[:400])
+    val_ds = TensorDataset(x[400:], y[400:])
+    train_loader = DataLoader(train_ds, batch_size=32, shuffle=True)
+    val_loader = DataLoader(val_ds, batch_size=64)
+
+    model = BaselineMLP(in_dim=16, hidden=64, out_dim=4)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=lr, weight_decay=weight_decay)
+    criterion = nn.CrossEntropyLoss()
+
+    last_train = 0.0
+    for _ in range(epochs):
+        last_train = train_one_epoch(model, train_loader, optimizer, criterion)
+
+    val_loss, val_acc = evaluate(model, val_loader, criterion)
+    return TrainStats(train_loss=last_train, val_loss=val_loss, val_acc=val_acc)
+
+
+if __name__ == "__main__":
+    stats = run_baseline()
+    assert 0.0 <= stats.val_acc <= 1.0
+    print(stats)

--- a/pytorchlings/exercises/68_accelerator_native_thinking/jit_vmap_pytree_mindset.py
+++ b/pytorchlings/exercises/68_accelerator_native_thinking/jit_vmap_pytree_mindset.py
@@ -1,0 +1,56 @@
+"""Exercise 68: accelerator-native thinking in a PyTorch-first workflow.
+
+Although JAX has jit/vmap/pytrees as core primitives,
+you can practice the same mental model in PyTorch with torch.compile,
+torch.func.vmap, and nested parameter structures.
+"""
+
+import torch
+from torch import nn
+from torch.func import functional_call, vmap
+
+
+def single_example_loss(params: dict[str, torch.Tensor], model: nn.Module, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    """Compute per-example cross entropy loss via functional_call."""
+    logits = functional_call(model, params, (x.unsqueeze(0),))
+    return nn.functional.cross_entropy(logits, y.unsqueeze(0))
+
+
+def batched_loss_with_vmap(model: nn.Module, x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    params = dict(model.named_parameters())
+
+    # TODO: vectorize single_example_loss across batch dimension with vmap
+    vmapped = vmap(lambda xb, yb: single_example_loss(params, model, xb, yb))
+    losses = vmapped(x, y)
+    return losses.mean()
+
+
+def compile_training_step(model: nn.Module):
+    """Return a compiled training-step function."""
+
+    def step(x: torch.Tensor, y: torch.Tensor, optimizer: torch.optim.Optimizer) -> float:
+        optimizer.zero_grad()
+        logits = model(x)
+        loss = nn.functional.cross_entropy(logits, y)
+        loss.backward()
+        optimizer.step()
+        return float(loss.item())
+
+    # TODO: tune compile mode/backend options for your environment
+    return torch.compile(step)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    model = nn.Sequential(nn.Linear(10, 32), nn.ReLU(), nn.Linear(32, 3))
+    x = torch.randn(16, 10)
+    y = torch.randint(0, 3, (16,))
+
+    loss = batched_loss_with_vmap(model, x, y)
+    assert loss.ndim == 0
+
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    step_fn = compile_training_step(model)
+    step_loss = step_fn(x, y, optimizer)
+    assert step_loss > 0
+    print("exercise 68 smoke check passed")

--- a/pytorchlings/exercises/69_rdkit_pyg_pipeline/rdkit_to_pyg_dataset.py
+++ b/pytorchlings/exercises/69_rdkit_pyg_pipeline/rdkit_to_pyg_dataset.py
@@ -1,0 +1,61 @@
+"""Exercise 69: molecule files -> RDKit featurization -> PyG Data objects.
+
+This exercise is intentionally dependency-heavy and mirrors realistic chemistry ML preprocessing.
+"""
+
+from typing import Iterable
+
+import torch
+
+try:
+    from rdkit import Chem
+    from torch_geometric.data import Data
+except ImportError as exc:  # pragma: no cover - environment dependent
+    raise SystemExit(
+        "Install rdkit and torch-geometric to run this exercise."
+    ) from exc
+
+
+ATOM_SET = ["H", "C", "N", "O", "F", "P", "S", "Cl", "Br", "I"]
+
+
+def atom_features(atom: Chem.Atom) -> list[float]:
+    """Simple handcrafted atom features for baseline GNNs."""
+    one_hot = [float(atom.GetSymbol() == sym) for sym in ATOM_SET]
+    numeric = [
+        float(atom.GetAtomicNum()),
+        float(atom.GetDegree()),
+        float(atom.GetFormalCharge()),
+        float(atom.GetIsAromatic()),
+    ]
+    return one_hot + numeric
+
+
+def smiles_to_data(smiles: str, y_value: float) -> Data:
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        raise ValueError(f"Invalid SMILES: {smiles}")
+
+    x = torch.tensor([atom_features(a) for a in mol.GetAtoms()], dtype=torch.float32)
+
+    edge_pairs = []
+    for bond in mol.GetBonds():
+        i, j = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
+        edge_pairs.extend([(i, j), (j, i)])
+
+    edge_index = torch.tensor(edge_pairs, dtype=torch.long).t().contiguous()
+
+    # TODO: add richer edge features (bond type, conjugation, stereo)
+    return Data(x=x, edge_index=edge_index, y=torch.tensor([y_value], dtype=torch.float32))
+
+
+def build_dataset(rows: Iterable[tuple[str, float]]) -> list[Data]:
+    return [smiles_to_data(smiles, y) for smiles, y in rows]
+
+
+if __name__ == "__main__":
+    rows = [("CCO", 0.1), ("c1ccccc1", 0.5), ("CC(=O)O", -0.2)]
+    dataset = build_dataset(rows)
+    assert len(dataset) == 3
+    assert dataset[0].x.ndim == 2
+    print("exercise 69 smoke check passed")

--- a/pytorchlings/exercises/70_gnn_model_comparison/gcn_gin_gat_benchmark.py
+++ b/pytorchlings/exercises/70_gnn_model_comparison/gcn_gin_gat_benchmark.py
@@ -1,0 +1,79 @@
+"""Exercise 70: compare GCN, GIN, and GAT on one molecular task.
+
+What to implement:
+1) shared training/evaluation loops
+2) consistent splits and seeds
+3) one ablation on node/edge feature choices
+"""
+
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+from torch_geometric.nn import GATConv, GCNConv, GINConv, global_mean_pool
+
+
+class GCNModel(nn.Module):
+    def __init__(self, in_dim: int, hidden: int, out_dim: int):
+        super().__init__()
+        self.conv1 = GCNConv(in_dim, hidden)
+        self.conv2 = GCNConv(hidden, hidden)
+        self.head = nn.Linear(hidden, out_dim)
+
+    def forward(self, x, edge_index, batch):
+        h = self.conv1(x, edge_index).relu()
+        h = self.conv2(h, edge_index).relu()
+        return self.head(global_mean_pool(h, batch))
+
+
+class GINModel(nn.Module):
+    def __init__(self, in_dim: int, hidden: int, out_dim: int):
+        super().__init__()
+        mlp1 = nn.Sequential(nn.Linear(in_dim, hidden), nn.ReLU(), nn.Linear(hidden, hidden))
+        mlp2 = nn.Sequential(nn.Linear(hidden, hidden), nn.ReLU(), nn.Linear(hidden, hidden))
+        self.conv1 = GINConv(mlp1)
+        self.conv2 = GINConv(mlp2)
+        self.head = nn.Linear(hidden, out_dim)
+
+    def forward(self, x, edge_index, batch):
+        h = self.conv1(x, edge_index).relu()
+        h = self.conv2(h, edge_index).relu()
+        return self.head(global_mean_pool(h, batch))
+
+
+class GATModel(nn.Module):
+    def __init__(self, in_dim: int, hidden: int, out_dim: int, heads: int = 4):
+        super().__init__()
+        self.conv1 = GATConv(in_dim, hidden, heads=heads)
+        self.conv2 = GATConv(hidden * heads, hidden, heads=1)
+        self.head = nn.Linear(hidden, out_dim)
+
+    def forward(self, x, edge_index, batch):
+        h = self.conv1(x, edge_index).relu()
+        h = self.conv2(h, edge_index).relu()
+        return self.head(global_mean_pool(h, batch))
+
+
+@dataclass
+class RunResult:
+    model_name: str
+    val_metric: float
+
+
+def train_eval_stub(model: nn.Module) -> float:
+    """TODO: replace with full train/val loop using scaffold split and identical protocol."""
+    n_params = sum(p.numel() for p in model.parameters())
+    return float(torch.log(torch.tensor(n_params, dtype=torch.float32)).item())
+
+
+if __name__ == "__main__":
+    in_dim, hidden, out_dim = 16, 32, 1
+    models = {
+        "gcn": GCNModel(in_dim, hidden, out_dim),
+        "gin": GINModel(in_dim, hidden, out_dim),
+        "gat": GATModel(in_dim, hidden, out_dim),
+    }
+
+    results = [RunResult(name, train_eval_stub(m)) for name, m in models.items()]
+    assert len(results) == 3
+    print(results)

--- a/pytorchlings/exercises/71_protein_ligand_geometry/protein_ligand_graph_vs_geometry.py
+++ b/pytorchlings/exercises/71_protein_ligand_geometry/protein_ligand_graph_vs_geometry.py
@@ -1,0 +1,46 @@
+"""Exercise 71: compare graph-only vs geometry-aware protein-ligand models."""
+
+import torch
+from torch import nn
+
+
+class GraphOnlyScorer(nn.Module):
+    def __init__(self, in_dim: int, hidden: int):
+        super().__init__()
+        self.mlp = nn.Sequential(nn.Linear(in_dim, hidden), nn.ReLU(), nn.Linear(hidden, 1))
+
+    def forward(self, node_features: torch.Tensor) -> torch.Tensor:
+        pooled = node_features.mean(dim=0, keepdim=True)
+        return self.mlp(pooled).squeeze(-1)
+
+
+class GeometryAwareScorer(nn.Module):
+    def __init__(self, in_dim: int, hidden: int):
+        super().__init__()
+        self.feature_proj = nn.Linear(in_dim, hidden)
+        self.dist_proj = nn.Linear(1, hidden)
+        self.head = nn.Linear(hidden, 1)
+
+    def forward(self, node_features: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
+        pairwise_dist = torch.cdist(coords, coords)
+        geom_signal = pairwise_dist.mean(dim=1, keepdim=True)
+
+        # TODO: replace mean distance with richer geometric basis features
+        h = self.feature_proj(node_features) + self.dist_proj(geom_signal)
+        pooled = h.mean(dim=0, keepdim=True)
+        return self.head(torch.relu(pooled)).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(0)
+    n, f = 40, 20
+    x = torch.randn(n, f)
+    xyz = torch.randn(n, 3)
+
+    g = GraphOnlyScorer(in_dim=f, hidden=64)
+    geom = GeometryAwareScorer(in_dim=f, hidden=64)
+
+    s1 = g(x)
+    s2 = geom(x, xyz)
+    assert s1.numel() == 1 and s2.numel() == 1
+    print("exercise 71 smoke check passed")

--- a/pytorchlings/exercises/72_research_framework/reproducible_training_stack.py
+++ b/pytorchlings/exercises/72_research_framework/reproducible_training_stack.py
@@ -1,0 +1,81 @@
+"""Exercise 72: mini research-engineering training framework.
+
+Checklist:
+- deterministic seeds
+- config-driven setup
+- checkpointing
+- metric logging
+- multi-GPU readiness hooks
+"""
+
+from dataclasses import dataclass, asdict
+import json
+from pathlib import Path
+import random
+
+import torch
+
+
+@dataclass
+class ExperimentConfig:
+    seed: int = 42
+    run_name: str = "baseline"
+    lr: float = 1e-3
+    batch_size: int = 64
+    epochs: int = 3
+    output_dir: str = "artifacts/exp72"
+
+
+def set_seed(seed: int) -> None:
+    random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def save_config(cfg: ExperimentConfig) -> Path:
+    out_dir = Path(cfg.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cfg_path = out_dir / "config.json"
+    cfg_path.write_text(json.dumps(asdict(cfg), indent=2))
+    return cfg_path
+
+
+def save_checkpoint(path: Path, model: torch.nn.Module, optimizer: torch.optim.Optimizer, step: int) -> None:
+    payload = {
+        "step": step,
+        "model": model.state_dict(),
+        "optimizer": optimizer.state_dict(),
+    }
+    torch.save(payload, path)
+
+
+def train_stub(cfg: ExperimentConfig) -> dict[str, float]:
+    set_seed(cfg.seed)
+    save_config(cfg)
+
+    model = torch.nn.Linear(10, 2)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr)
+
+    last_loss = 0.0
+    for step in range(cfg.epochs):
+        x = torch.randn(cfg.batch_size, 10)
+        y = torch.randint(0, 2, (cfg.batch_size,))
+
+        optimizer.zero_grad()
+        logits = model(x)
+        loss = torch.nn.functional.cross_entropy(logits, y)
+        loss.backward()
+        optimizer.step()
+        last_loss = float(loss.item())
+
+    ckpt_path = Path(cfg.output_dir) / "last.ckpt"
+    save_checkpoint(ckpt_path, model, optimizer, cfg.epochs)
+
+    # TODO: add profiler traces and distributed training hooks
+    return {"final_loss": last_loss}
+
+
+if __name__ == "__main__":
+    metrics = train_stub(ExperimentConfig())
+    assert "final_loss" in metrics
+    print(metrics)

--- a/pytorchlings/exercises/73_ablation_failure_analysis/ablation_and_failure_report.py
+++ b/pytorchlings/exercises/73_ablation_failure_analysis/ablation_and_failure_report.py
@@ -1,0 +1,58 @@
+"""Exercise 73: structure a real ablation + failure-analysis workflow.
+
+Deliverables:
+- 3-5 ablation experiments
+- failure slice report
+- concise markdown summary
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class AblationResult:
+    name: str
+    metric: float
+    note: str
+
+
+def rank_runs(results: list[AblationResult]) -> list[AblationResult]:
+    """Higher metric is better."""
+    return sorted(results, key=lambda r: r.metric, reverse=True)
+
+
+def write_markdown_report(results: list[AblationResult], out_path: Path) -> None:
+    ranked = rank_runs(results)
+
+    lines = [
+        "# Ablation Report",
+        "",
+        "## Ranked runs",
+        "",
+    ]
+
+    for idx, run in enumerate(ranked, start=1):
+        lines.append(f"{idx}. **{run.name}**: metric={run.metric:.4f} — {run.note}")
+
+    lines += [
+        "",
+        "## Failure analysis prompts",
+        "",
+        "- Which data slices degrade most?",
+        "- What hypotheses explain these failures?",
+        "- What follow-up experiments would de-risk deployment?",
+    ]
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    demo = [
+        AblationResult("baseline", 0.702, "reference"),
+        AblationResult("+edge_features", 0.731, "improves aromatic systems"),
+        AblationResult("+geometry", 0.748, "best overall, slower"),
+    ]
+    write_markdown_report(demo, Path("artifacts/exp73/ablation_report.md"))
+    print("exercise 73 report written")


### PR DESCRIPTION
### Motivation

- Provide an interview- and research-focused extension to the existing PyTorch/PyG track that directs learners from math refresh through end-to-end ML research workflows. 
- Create compact, runnable scaffolds that surface role-relevant skills: matrix/Jacobian drills, writing a paper baseline from scratch, accelerator-native patterns, molecule preprocessing, GNN model comparison, protein–ligand geometry, reproducible training stacks, and structured ablation/failure analysis. 
- Make it easy to convert study into evidence by giving explicit exercise points that map directly to portfolio-style deliverables and ablations.

### Description

- Added eight new exercise scaffolds under `pytorchlings/exercises/66` through `pytorchlings/exercises/73`, each containing a focused Python script and a brief smoke-check harness; the exercises are: `66` Math-for-ML drills, `67` Paper-baseline training, `68` Accelerator-native patterns (`torch.compile`/`vmap`/functional_call), `69` RDKit→PyG pipeline, `70` GCN/GIN/GAT comparison scaffold, `71` protein–ligand graph vs geometry comparison, `72` mini reproducible training stack, and `73` ablation + failure analysis reporter. 
- Updated `pytorchlings/EXERCISES.md` to list the new numbered entries `66`–`73` with short descriptions and file paths. 
- Updated `pytorchlings/README.md` suggested flow to mention the new interview-focused extension (exercises 66–73).

### Testing

- Ran `python -m compileall` against the new exercise directories (`pytorchlings/exercises/66`–`73`) to ensure all new Python files compile without syntax errors, and the compilation completed successfully. 
- Each exercise file includes a lightweight `if __name__ == "__main__"` smoke-check; the code was written to pass those quick runtime assertions when dependencies are available (e.g., RDKit/PyG for exercise `69`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d90b9106e0832ea595287705b36c01)