### PR TITLE
Add BioAI Research Engineer interview exercise pack (PyTorch stubs and README)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -30,3 +30,79 @@ If you need to build the original geometry binary, use:
 ```bash
 g++ -I lib/eigen-3.4.0/ -I lib/ cxx/geometry_functions.cxx main.cxx -o ./main
 ```
+
+## Research Engineer Interview Exercise Pack (BioAI)
+
+The following exercises are designed for hiring/recruiting loops for a Research Engineer role focused on AI for drug discovery.
+
+### 1) Neural Network Fundamentals (take-home, 60–90 min)
+
+- Build a small neural network to predict a binary property from sequence-like inputs.
+- Compare at least two architectures (for example: MLP vs. 1D CNN or a tiny Transformer).
+- Report train/validation metrics, overfitting behavior, and one optimization you attempted.
+
+### 2) Distributed Training Systems (practical, 90 min)
+
+- Start from a single-GPU training script and describe/adapt it for multi-GPU training.
+- Identify bottlenecks (data loading, communication overhead, memory) and mitigation strategies.
+- Discuss tradeoffs between data parallel and sharded approaches.
+
+### 3) Profiling and Optimization (debug session, 60 min)
+
+- Profile a deliberately inefficient training script.
+- Identify the top bottlenecks and implement (or propose) fixes.
+- Show before/after runtime or memory measurements.
+
+### 4) BioAI Problem Framing (whiteboard, 45 min)
+
+Prompt: design an ML workflow to prioritize antibody candidates for a hard-to-drug target.
+
+Candidate should cover:
+- data sources (sequence, structure, assay)
+- objective definition (affinity, specificity, developability)
+- evaluation plan (offline metrics + wet-lab handoff)
+- uncertainty and failure-mode handling
+
+### 5) Foundation Model Design Case (system design, 60 min)
+
+Prompt: design a biology/disease foundation model to improve target elucidation and patient stratification.
+
+Candidate should address:
+- multimodal inputs and pretraining objectives
+- fine-tuning strategy for downstream tasks
+- interpretability, bias, and deployment considerations
+
+### 6) Code Quality + Collaboration (pairing, 45 min)
+
+- Refactor a small research code sample for clarity.
+- Add basic tests and concise documentation.
+- Explain decisions while pairing with the interviewer.
+
+### 7) Research Communication (presentation, 20–30 min)
+
+- Present one prior project/public repo contribution.
+- Explain approach, tradeoffs, failures, and next steps.
+
+### Suggested scoring rubric (1–4 each)
+
+- ML fundamentals
+- Scaling/systems engineering
+- Optimization/debugging
+- BioAI reasoning
+- Code quality
+- Collaboration and communication
+
+A strong overall signal is typically 3+ in most categories with at least one area of clear excellence.
+
+## Implemented Python exercises (PyTorch)
+
+Concrete exercise scripts are available at:
+
+- `src/pytorch_practice/interview_exercises/ex1_sequence_binary_classifier.py`
+- `src/pytorch_practice/interview_exercises/ex2_distributed_training_stub.py`
+- `src/pytorch_practice/interview_exercises/ex3_profile_and_optimize.py`
+- `src/pytorch_practice/interview_exercises/ex4_bioai_multitask_stub.py`
+- `src/pytorch_practice/interview_exercises/README.md`
+
+These are executable Python stubs that can be used directly in take-home or live interview settings.
+

--- a/src/pytorch_practice/interview_exercises/README.md
+++ b/src/pytorch_practice/interview_exercises/README.md
@@ -1,0 +1,35 @@
+# BioAI Research Engineer - Python Exercise Pack
+
+This folder contains practical Python exercises designed for research-engineering interviews focused on AI for drug discovery.
+
+## Exercises
+
+1. `ex1_sequence_binary_classifier.py`
+   - Build and compare two PyTorch architectures on synthetic sequence data.
+   - Focus: model building, training loops, evaluation, and overfitting analysis.
+
+2. `ex2_distributed_training_stub.py`
+   - Convert a single-process training workflow into Distributed Data Parallel (DDP).
+   - Focus: distributed systems fundamentals, data partitioning, and synchronization.
+
+3. `ex3_profile_and_optimize.py`
+   - Profile an intentionally inefficient training script and optimize bottlenecks.
+   - Focus: performance profiling, mixed precision, and input pipeline tuning.
+
+4. `ex4_bioai_multitask_stub.py`
+   - Implement a multi-head model for target affinity, developability, and toxicity proxy tasks.
+   - Focus: multi-task learning design and BioAI framing.
+
+## Suggested usage
+
+- Ask candidates to complete 1-2 scripts as take-home work.
+- Pair on one script live (45-60 min) to evaluate debugging and communication.
+- Use the same scoring rubric across candidates for consistency.
+
+## Optional scoring dimensions (1-4)
+
+- PyTorch fundamentals
+- Data & evaluation rigor
+- Systems/performance optimization
+- BioAI reasoning
+- Code quality and communication

--- a/src/pytorch_practice/interview_exercises/ex1_sequence_binary_classifier.py
+++ b/src/pytorch_practice/interview_exercises/ex1_sequence_binary_classifier.py
@@ -1,0 +1,133 @@
+"""Exercise 1: Sequence binary classification in PyTorch.
+
+Task:
+1) Implement both `MLPClassifier` and `TinyConvClassifier`.
+2) Train both models on the synthetic dataset.
+3) Compare validation AUC and discuss overfitting behavior.
+4) Add one improvement (e.g., dropout, weight decay, scheduler).
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, Dataset, random_split
+
+
+def seed_everything(seed: int = 42) -> None:
+    random.seed(seed)
+    torch.manual_seed(seed)
+
+
+class SyntheticSequenceDataset(Dataset):
+    def __init__(self, n_samples: int = 4000, seq_len: int = 64, vocab_size: int = 24):
+        self.seq_len = seq_len
+        self.vocab_size = vocab_size
+        self.samples = torch.randint(0, vocab_size, (n_samples, seq_len))
+
+        # Toy label rule: positive if high count of tokens in a motif set.
+        motif_tokens = {2, 7, 13, 19}
+        counts = torch.zeros(n_samples)
+        for t in motif_tokens:
+            counts += (self.samples == t).sum(dim=1)
+        self.labels = (counts > 12).float().unsqueeze(1)
+
+    def __len__(self) -> int:
+        return self.samples.shape[0]
+
+    def __getitem__(self, idx: int):
+        return self.samples[idx], self.labels[idx]
+
+
+class MLPClassifier(nn.Module):
+    """TODO: candidate implements."""
+
+    def __init__(self, vocab_size: int, seq_len: int, emb_dim: int = 16):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, emb_dim)
+        self.net = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(seq_len * emb_dim, 128),
+            nn.ReLU(),
+            nn.Dropout(0.2),
+            nn.Linear(128, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(self.embed(x))
+
+
+class TinyConvClassifier(nn.Module):
+    """TODO: candidate compares against MLP baseline."""
+
+    def __init__(self, vocab_size: int, emb_dim: int = 16):
+        super().__init__()
+        self.embed = nn.Embedding(vocab_size, emb_dim)
+        self.net = nn.Sequential(
+            nn.Conv1d(emb_dim, 64, kernel_size=5, padding=2),
+            nn.ReLU(),
+            nn.Conv1d(64, 64, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.AdaptiveMaxPool1d(1),
+            nn.Flatten(),
+            nn.Linear(64, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        z = self.embed(x).transpose(1, 2)
+        return self.net(z)
+
+
+@dataclass
+class TrainConfig:
+    batch_size: int = 64
+    lr: float = 1e-3
+    epochs: int = 5
+
+
+def train_one_epoch(model: nn.Module, loader: DataLoader, opt: torch.optim.Optimizer, loss_fn: nn.Module) -> float:
+    model.train()
+    total = 0.0
+    for x, y in loader:
+        logits = model(x)
+        loss = loss_fn(logits, y)
+        opt.zero_grad()
+        loss.backward()
+        opt.step()
+        total += float(loss.item())
+    return total / len(loader)
+
+
+def evaluate(model: nn.Module, loader: DataLoader, loss_fn: nn.Module) -> float:
+    model.eval()
+    total = 0.0
+    with torch.no_grad():
+        for x, y in loader:
+            logits = model(x)
+            total += float(loss_fn(logits, y).item())
+    return total / len(loader)
+
+
+def main() -> None:
+    seed_everything(7)
+    ds = SyntheticSequenceDataset()
+    train_size = int(0.8 * len(ds))
+    train_ds, val_ds = random_split(ds, [train_size, len(ds) - train_size])
+    train_loader = DataLoader(train_ds, batch_size=64, shuffle=True)
+    val_loader = DataLoader(val_ds, batch_size=64)
+
+    model = MLPClassifier(vocab_size=24, seq_len=64)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    loss_fn = nn.BCEWithLogitsLoss()
+
+    for epoch in range(1, 6):
+        tr = train_one_epoch(model, train_loader, opt, loss_fn)
+        va = evaluate(model, val_loader, loss_fn)
+        print(f"epoch={epoch} train_loss={tr:.4f} val_loss={va:.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pytorch_practice/interview_exercises/ex2_distributed_training_stub.py
+++ b/src/pytorch_practice/interview_exercises/ex2_distributed_training_stub.py
@@ -1,0 +1,79 @@
+"""Exercise 2: Distributed training stub with PyTorch DDP.
+
+Run example:
+  torchrun --nproc_per_node=2 src/pytorch_practice/interview_exercises/ex2_distributed_training_stub.py
+
+Task:
+- Fill in DDP initialization, DistributedSampler wiring, and rank-aware logging/checkpointing.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+import torch.distributed as dist
+from torch import nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.data import DataLoader, TensorDataset
+from torch.utils.data.distributed import DistributedSampler
+
+
+def setup_ddp() -> tuple[int, int, int]:
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+    rank = int(os.environ.get("RANK", 0))
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+
+    if world_size > 1:
+        dist.init_process_group(backend="gloo")
+    return local_rank, rank, world_size
+
+
+def cleanup_ddp(world_size: int) -> None:
+    if world_size > 1 and dist.is_initialized():
+        dist.destroy_process_group()
+
+
+def build_loader(rank: int, world_size: int) -> DataLoader:
+    x = torch.randn(2048, 32)
+    y = (x[:, :4].sum(dim=1, keepdim=True) > 0).float()
+    ds = TensorDataset(x, y)
+
+    sampler = DistributedSampler(ds, num_replicas=world_size, rank=rank, shuffle=True) if world_size > 1 else None
+    return DataLoader(ds, batch_size=64, sampler=sampler, shuffle=sampler is None)
+
+
+def main() -> None:
+    local_rank, rank, world_size = setup_ddp()
+
+    device = torch.device("cpu")
+    model = nn.Sequential(nn.Linear(32, 64), nn.ReLU(), nn.Linear(64, 1)).to(device)
+    if world_size > 1:
+        model = DDP(model)
+
+    loader = build_loader(rank, world_size)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    loss_fn = nn.BCEWithLogitsLoss()
+
+    for epoch in range(3):
+        if hasattr(loader, "sampler") and isinstance(loader.sampler, DistributedSampler):
+            loader.sampler.set_epoch(epoch)
+
+        total = 0.0
+        for x, y in loader:
+            x, y = x.to(device), y.to(device)
+            logits = model(x)
+            loss = loss_fn(logits, y)
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            total += float(loss.item())
+
+        if rank == 0:
+            print(f"epoch={epoch} loss={total/len(loader):.4f} world_size={world_size}")
+
+    cleanup_ddp(world_size)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pytorch_practice/interview_exercises/ex3_profile_and_optimize.py
+++ b/src/pytorch_practice/interview_exercises/ex3_profile_and_optimize.py
@@ -1,0 +1,66 @@
+"""Exercise 3: Profile and optimize a slow training loop.
+
+Task:
+1) Run this script and capture baseline runtime.
+2) Use torch.profiler (or cProfile) to identify bottlenecks.
+3) Implement at least 2 optimizations and report impact.
+
+Hints:
+- increase batch size carefully
+- avoid repeated tensor allocations in loop
+- use num_workers/pin_memory when using CUDA
+"""
+
+from __future__ import annotations
+
+import time
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+
+def build_data() -> DataLoader:
+    x = torch.randn(8000, 128)
+    y = torch.randint(0, 2, (8000, 1)).float()
+    ds = TensorDataset(x, y)
+    # Intentionally conservative defaults for candidate to tune.
+    return DataLoader(ds, batch_size=16, shuffle=True, num_workers=0)
+
+
+def build_model() -> nn.Module:
+    return nn.Sequential(
+        nn.Linear(128, 256),
+        nn.ReLU(),
+        nn.Linear(256, 256),
+        nn.ReLU(),
+        nn.Linear(256, 1),
+    )
+
+
+def main() -> None:
+    loader = build_data()
+    model = build_model()
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+    loss_fn = nn.BCEWithLogitsLoss()
+
+    t0 = time.perf_counter()
+    for epoch in range(3):
+        total = 0.0
+        for x, y in loader:
+            # Intentionally suboptimal pattern (extra allocation) for optimization exercise.
+            x = x + torch.zeros_like(x)
+            logits = model(x)
+            loss = loss_fn(logits, y)
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            total += float(loss.item())
+        print(f"epoch={epoch} loss={total/len(loader):.4f}")
+
+    elapsed = time.perf_counter() - t0
+    print(f"baseline_elapsed_sec={elapsed:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pytorch_practice/interview_exercises/ex4_bioai_multitask_stub.py
+++ b/src/pytorch_practice/interview_exercises/ex4_bioai_multitask_stub.py
@@ -1,0 +1,77 @@
+"""Exercise 4: BioAI multi-task model (toy setup).
+
+Goal:
+Train a model that predicts three targets from a sequence embedding:
+- affinity_score (regression)
+- developability_flag (binary)
+- toxicity_proxy (regression)
+
+Task:
+- Implement weighted multi-task loss.
+- Add metric tracking per head.
+- Propose how this toy setup maps to a realistic wet-lab loop.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+
+class MultiTaskNet(nn.Module):
+    def __init__(self, input_dim: int = 128):
+        super().__init__()
+        self.trunk = nn.Sequential(nn.Linear(input_dim, 256), nn.ReLU(), nn.Linear(256, 128), nn.ReLU())
+        self.affinity_head = nn.Linear(128, 1)
+        self.dev_head = nn.Linear(128, 1)
+        self.tox_head = nn.Linear(128, 1)
+
+    def forward(self, x: torch.Tensor):
+        h = self.trunk(x)
+        return {
+            "affinity": self.affinity_head(h),
+            "developability": self.dev_head(h),
+            "toxicity": self.tox_head(h),
+        }
+
+
+def make_loader(n: int = 3000, input_dim: int = 128) -> DataLoader:
+    x = torch.randn(n, input_dim)
+    affinity = x[:, :8].sum(dim=1, keepdim=True) + 0.1 * torch.randn(n, 1)
+    developability = (x[:, 8:16].sum(dim=1, keepdim=True) > 0).float()
+    toxicity = x[:, 16:24].mean(dim=1, keepdim=True) + 0.1 * torch.randn(n, 1)
+    ds = TensorDataset(x, affinity, developability, toxicity)
+    return DataLoader(ds, batch_size=64, shuffle=True)
+
+
+def main() -> None:
+    model = MultiTaskNet()
+    loader = make_loader()
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    bce = nn.BCEWithLogitsLoss()
+    mse = nn.MSELoss()
+
+    for epoch in range(3):
+        running = 0.0
+        for x, affinity, developability, toxicity in loader:
+            out = model(x)
+
+            # Candidate can tune weights and justify choices.
+            loss = (
+                1.0 * mse(out["affinity"], affinity)
+                + 0.7 * bce(out["developability"], developability)
+                + 0.8 * mse(out["toxicity"], toxicity)
+            )
+
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+            running += float(loss.item())
+
+        print(f"epoch={epoch} multitask_loss={running/len(loader):.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Add a concise, reproducible set of interview exercises and stubs to support hiring for Research Engineer roles focused on AI for drug discovery. 

### Description

- Extend the top-level `README.txt` with a new `Research Engineer Interview Exercise Pack (BioAI)` section describing exercises and scoring guidance. 
- Add `src/pytorch_practice/interview_exercises/README.md` describing the exercise pack and suggested usage. 
- Add four executable PyTorch exercise stubs: `ex1_sequence_binary_classifier.py` (synthetic sequence dataset with `MLPClassifier` and `TinyConvClassifier`), `ex2_distributed_training_stub.py` (DDP initialization and `DistributedSampler` wiring stub), `ex3_profile_and_optimize.py` (profiling/optimization baseline with intentionally suboptimal loop), and `ex4_bioai_multitask_stub.py` (toy multi-task model with weighted loss heads). 

### Testing

- No automated tests were added or modified for these artifacts and CI was not changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8e68c5f64832e8ee6e685b905531c)