### PR TITLE
Add chemistry-focused exercises 74-78 and interview exercise pack docs

### DIFF
--- a/pytorchlings/EXERCISES.md
+++ b/pytorchlings/EXERCISES.md
@@ -80,3 +80,9 @@
 | 71 | PyTorch | Protein-ligand graph-only vs geometry-aware comparison | `exercises/71_protein_ligand_geometry/protein_ligand_graph_vs_geometry.py` | `N/A (exercise scaffold)` |
 | 72 | PyTorch | Reproducible training framework scaffold | `exercises/72_research_framework/reproducible_training_stack.py` | `N/A (exercise scaffold)` |
 | 73 | PyTorch | Ablation + failure-analysis report workflow | `exercises/73_ablation_failure_analysis/ablation_and_failure_report.py` | `N/A (exercise scaffold)` |
+| 74 | PyTorch | Fingerprint QSAR MLP baseline scaffold | `exercises/74_fingerprint_qsar_mlp/fingerprint_qsar_mlp.py` | `N/A (exercise scaffold)` |
+| 75 | PyTorch | Multitask QSAR with masked missing labels | `exercises/75_multitask_qsar_masked/multitask_qsar_masked.py` | `N/A (exercise scaffold)` |
+| 76 | PyTorch | Molecular graph message passing (from scratch) | `exercises/76_molecular_graph_message_passing/molecular_graph_message_passing.py` | `N/A (exercise scaffold)` |
+| 77 | PyTorch | SMILES LSTM property prediction scaffold | `exercises/77_smiles_lstm_property/smiles_lstm_property.py` | `N/A (exercise scaffold)` |
+| 78 | PyTorch | Protein-ligand 3D CNN scoring scaffold | `exercises/78_protein_ligand_3dcnn/protein_ligand_3dcnn.py` | `N/A (exercise scaffold)` |
+

--- a/pytorchlings/README.md
+++ b/pytorchlings/README.md
@@ -24,6 +24,7 @@ A rustlings-style practice track for **PyTorch** and **PyTorch Geometric (PyG)**
 - Add 60-61 for Optuna-based hyperparameter optimization (PyTorch MLP + scikit-learn baseline tuning).
 - Add 62-65 for chemistry-oriented generative modeling, hill-climbing evals, and slice-based scientific error analysis.
 - Add 66-73 for interview-focused research practice: math refresh drills, from-scratch baselines, accelerator-native patterns, RDKit/PyG pipelines, graph-vs-geometry modeling, reproducible training stacks, and ablation reporting.
+- Add 74-78 for chemistry-model progression examples: fingerprint MLP baseline, multitask masking, molecular message passing, SMILES LSTM, and protein-ligand 3D CNN.
 
 ## Quick check command
 
@@ -89,3 +90,14 @@ Exercises 62-65 target role-relevant fundamentals for generative science workflo
 - Hill-climb eval loops for iterative model improvement
 - Slice-wise scientific error analysis + markdown reporting for collaboration
 
+
+
+## Chemistry architecture progression extension
+
+Exercises 74-78 provide direct hands-on scaffolds matching a practical chemistry deep-learning progression:
+
+- Fingerprint/descriptors -> feed-forward QSAR baseline
+- Multitask DNN with explicit missing-label masking
+- Molecular graph message passing and graph-level readout
+- SMILES LSTM sequence modeling
+- 3D CNN scoring on voxelized protein-ligand neighborhoods

--- a/pytorchlings/exercises/74_fingerprint_qsar_mlp/fingerprint_qsar_mlp.py
+++ b/pytorchlings/exercises/74_fingerprint_qsar_mlp/fingerprint_qsar_mlp.py
@@ -1,0 +1,82 @@
+"""Exercise 74: feed-forward QSAR baseline on fingerprint-like features.
+
+Goal:
+- implement a strong chemistry baseline with an MLP
+- practice regression loop + RMSE reporting
+- compare with a non-neural baseline later
+"""
+
+import math
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset
+
+
+class FingerprintMLP(nn.Module):
+    def __init__(self, in_dim: int = 256, hidden_dims: tuple[int, int] = (128, 64), dropout: float = 0.1):
+        super().__init__()
+        h1, h2 = hidden_dims
+        self.net = nn.Sequential(
+            nn.Linear(in_dim, h1),
+            nn.ReLU(),
+            nn.Dropout(dropout),
+            nn.Linear(h1, h2),
+            nn.ReLU(),
+            nn.Linear(h2, 1),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x).squeeze(-1)
+
+
+def rmse(pred: torch.Tensor, target: torch.Tensor) -> float:
+    return math.sqrt(torch.mean((pred - target) ** 2).item())
+
+
+def make_synthetic_qsar(n: int = 512, d: int = 256) -> tuple[torch.Tensor, torch.Tensor]:
+    torch.manual_seed(74)
+    x = torch.randint(0, 2, (n, d), dtype=torch.float32)
+    w = torch.randn(d)
+    y = x @ w / d + 0.1 * torch.randn(n)
+    return x, y
+
+
+def train_epoch(model: nn.Module, loader: DataLoader, opt: torch.optim.Optimizer) -> float:
+    model.train()
+    loss_fn = nn.MSELoss()
+    running, n = 0.0, 0
+
+    for xb, yb in loader:
+        opt.zero_grad()
+        pred = model(xb)
+        loss = loss_fn(pred, yb)
+
+        # TODO: add learning-rate scheduler step and gradient clipping
+        loss.backward()
+        opt.step()
+
+        running += loss.item() * xb.size(0)
+        n += xb.size(0)
+    return running / max(n, 1)
+
+
+if __name__ == "__main__":
+    x, y = make_synthetic_qsar()
+    train_ds = TensorDataset(x[:400], y[:400])
+    val_x, val_y = x[400:], y[400:]
+
+    loader = DataLoader(train_ds, batch_size=32, shuffle=True)
+    model = FingerprintMLP(in_dim=x.size(1))
+    opt = torch.optim.AdamW(model.parameters(), lr=3e-3, weight_decay=1e-4)
+
+    for _ in range(5):
+        train_epoch(model, loader, opt)
+
+    model.eval()
+    with torch.no_grad():
+        val_pred = model(val_x)
+    val_rmse = rmse(val_pred, val_y)
+
+    assert val_rmse >= 0.0
+    print(f"exercise 74 smoke check passed | val_rmse={val_rmse:.4f}")

--- a/pytorchlings/exercises/75_multitask_qsar_masked/multitask_qsar_masked.py
+++ b/pytorchlings/exercises/75_multitask_qsar_masked/multitask_qsar_masked.py
@@ -1,0 +1,44 @@
+"""Exercise 75: multitask QSAR with missing-label masking.
+
+Goal:
+- implement shared-trunk multitask prediction
+- compute masked loss where some task labels are missing
+"""
+
+import torch
+from torch import nn
+
+
+class MultiTaskQSAR(nn.Module):
+    def __init__(self, in_dim: int, hidden: int, n_tasks: int):
+        super().__init__()
+        self.backbone = nn.Sequential(nn.Linear(in_dim, hidden), nn.ReLU(), nn.Linear(hidden, hidden), nn.ReLU())
+        self.head = nn.Linear(hidden, n_tasks)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.head(self.backbone(x))
+
+
+def masked_mse(pred: torch.Tensor, target: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+    # mask shape: [batch, n_tasks], values in {0,1}
+    sqerr = (pred - target) ** 2
+
+    # TODO: support task-wise weighting so rare tasks contribute fairly
+    denom = mask.sum().clamp_min(1.0)
+    return (sqerr * mask).sum() / denom
+
+
+if __name__ == "__main__":
+    torch.manual_seed(75)
+    bsz, in_dim, n_tasks = 16, 128, 5
+    x = torch.randn(bsz, in_dim)
+    y = torch.randn(bsz, n_tasks)
+    mask = (torch.rand(bsz, n_tasks) > 0.3).float()
+
+    model = MultiTaskQSAR(in_dim=in_dim, hidden=64, n_tasks=n_tasks)
+    pred = model(x)
+    loss = masked_mse(pred, y, mask)
+
+    assert pred.shape == (bsz, n_tasks)
+    assert torch.isfinite(loss)
+    print("exercise 75 smoke check passed")

--- a/pytorchlings/exercises/76_molecular_graph_message_passing/molecular_graph_message_passing.py
+++ b/pytorchlings/exercises/76_molecular_graph_message_passing/molecular_graph_message_passing.py
@@ -1,0 +1,53 @@
+"""Exercise 76: molecular graph message passing without external graph libs.
+
+Goal:
+- understand neighborhood aggregation mechanics
+- build a graph-level regressor with pooling
+"""
+
+import torch
+from torch import nn
+
+
+class SimpleMessagePassingLayer(nn.Module):
+    def __init__(self, in_dim: int, out_dim: int):
+        super().__init__()
+        self.self_lin = nn.Linear(in_dim, out_dim)
+        self.neigh_lin = nn.Linear(in_dim, out_dim)
+
+    def forward(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        deg = adj.sum(dim=-1, keepdim=True).clamp_min(1.0)
+        neigh_mean = (adj @ x) / deg
+        return torch.relu(self.self_lin(x) + self.neigh_lin(neigh_mean))
+
+
+class MolecularGraphRegressor(nn.Module):
+    def __init__(self, in_dim: int, hidden: int):
+        super().__init__()
+        self.mp1 = SimpleMessagePassingLayer(in_dim, hidden)
+        self.mp2 = SimpleMessagePassingLayer(hidden, hidden)
+        self.out = nn.Linear(hidden, 1)
+
+    def forward(self, x: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        h = self.mp1(x, adj)
+        h = self.mp2(h, adj)
+
+        # TODO: replace mean pooling with attention/readout mechanism
+        graph_repr = h.mean(dim=0, keepdim=True)
+        return self.out(graph_repr).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(76)
+    n, f = 24, 16
+    x = torch.randn(n, f)
+    a = torch.randint(0, 2, (n, n), dtype=torch.float32)
+    adj = torch.triu(a, diagonal=1)
+    adj = adj + adj.T
+    adj.fill_diagonal_(1.0)
+
+    model = MolecularGraphRegressor(in_dim=f, hidden=64)
+    pred = model(x, adj)
+
+    assert pred.numel() == 1
+    print("exercise 76 smoke check passed")

--- a/pytorchlings/exercises/77_smiles_lstm_property/smiles_lstm_property.py
+++ b/pytorchlings/exercises/77_smiles_lstm_property/smiles_lstm_property.py
@@ -1,0 +1,48 @@
+"""Exercise 77: SMILES-style sequence encoder with LSTM for property prediction.
+
+Goal:
+- tokenize toy chemistry strings
+- encode variable-length sequences with an LSTM
+"""
+
+import torch
+from torch import nn
+
+
+class SmilesLSTMRegressor(nn.Module):
+    def __init__(self, vocab_size: int, emb_dim: int = 32, hidden: int = 64):
+        super().__init__()
+        self.emb = nn.Embedding(vocab_size, emb_dim, padding_idx=0)
+        self.lstm = nn.LSTM(emb_dim, hidden, batch_first=True)
+        self.head = nn.Linear(hidden, 1)
+
+    def forward(self, token_ids: torch.Tensor) -> torch.Tensor:
+        e = self.emb(token_ids)
+        h, _ = self.lstm(e)
+
+        # TODO: replace last-token heuristic with packed sequence lengths
+        last = h[:, -1, :]
+        return self.head(last).squeeze(-1)
+
+
+def encode_strings(strings: list[str], stoi: dict[str, int], pad_to: int) -> torch.Tensor:
+    ids = []
+    for s in strings:
+        row = [stoi.get(ch, stoi["?"]) for ch in s][:pad_to]
+        row += [0] * (pad_to - len(row))
+        ids.append(row)
+    return torch.tensor(ids, dtype=torch.long)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(77)
+    vocab = ["<pad>", "C", "N", "O", "(", ")", "=", "#", "[", "]", "?", "1"]
+    stoi = {ch: i for i, ch in enumerate(vocab)}
+    smiles = ["CCO", "N#N", "C(=O)O", "CCN", "C1CC1"]
+    x = encode_strings(smiles, stoi, pad_to=10)
+
+    model = SmilesLSTMRegressor(vocab_size=len(vocab))
+    pred = model(x)
+
+    assert pred.shape == (len(smiles),)
+    print("exercise 77 smoke check passed")

--- a/pytorchlings/exercises/78_protein_ligand_3dcnn/protein_ligand_3dcnn.py
+++ b/pytorchlings/exercises/78_protein_ligand_3dcnn/protein_ligand_3dcnn.py
@@ -1,0 +1,41 @@
+"""Exercise 78: 3D CNN starter for protein-ligand voxel scoring.
+
+Goal:
+- build a minimal 3D convolutional scorer
+- practice volumetric tensor handling and shape debugging
+"""
+
+import torch
+from torch import nn
+
+
+class ProteinLigand3DCNN(nn.Module):
+    def __init__(self, in_channels: int = 8):
+        super().__init__()
+        self.encoder = nn.Sequential(
+            nn.Conv3d(in_channels, 16, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.MaxPool3d(2),
+            nn.Conv3d(16, 32, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.AdaptiveAvgPool3d((1, 1, 1)),
+        )
+        self.head = nn.Linear(32, 1)
+
+    def forward(self, grid: torch.Tensor) -> torch.Tensor:
+        z = self.encoder(grid).flatten(1)
+
+        # TODO: add test-time augmentation via random 3D rotations and average predictions
+        return self.head(z).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(78)
+    batch, channels, size = 4, 8, 20
+    voxel_grid = torch.randn(batch, channels, size, size, size)
+
+    model = ProteinLigand3DCNN(in_channels=channels)
+    pred = model(voxel_grid)
+
+    assert pred.shape == (batch,)
+    print("exercise 78 smoke check passed")

--- a/src/pytorch_practice/interview_exercises/README.md
+++ b/src/pytorch_practice/interview_exercises/README.md
@@ -20,6 +20,10 @@ This folder contains practical Python exercises designed for research-engineerin
    - Implement a multi-head model for target affinity, developability, and toxicity proxy tasks.
    - Focus: multi-task learning design and BioAI framing.
 
+5. `chemistry_nn_exercises.md`
+   - Progressive chemistry-focused PyTorch exercises: fingerprints -> multitask -> GNN -> SMILES LSTM -> 3D CNN.
+   - Focus: realistic dataset choices, project sequencing, and deliverables.
+
 ## Suggested usage
 
 - Ask candidates to complete 1-2 scripts as take-home work.

--- a/src/pytorch_practice/interview_exercises/chemistry_nn_exercises.md
+++ b/src/pytorch_practice/interview_exercises/chemistry_nn_exercises.md
@@ -1,0 +1,206 @@
+# Chemistry Neural-Network Exercises (PyTorch)
+
+This exercise set follows your preferred progression:
+
+1. MLP on fingerprints/descriptors (baseline)
+2. Multitask MLP on related endpoints
+3. GCN/MPNN on molecular graphs
+4. LSTM on SMILES strings
+5. 3D CNN on protein-ligand voxel grids
+
+---
+
+## Before you start: setup expectations
+
+- Use reproducible seeds (`torch`, `numpy`, Python `random`).
+- Report at least one baseline metric and one uncertainty/error analysis view.
+- Always compare against a simple non-deep baseline (e.g., random forest) for chemistry tasks.
+
+---
+
+## Exercise 1 — Fingerprint MLP (single-task regression)
+
+### Goal
+Predict a scalar molecular property from fixed-size molecular fingerprints.
+
+### Recommended dataset
+- **Local option (already in this repo):** `src/data/esol/raw/delaney-processed.csv`
+  - Typical target: aqueous solubility (`logS` style endpoint).
+
+### What to implement
+1. Build a dataset class from CSV.
+2. Convert SMILES to fingerprints (e.g., ECFP/Morgan) or use precomputed descriptors.
+3. Train an MLP with dropout + weight decay.
+4. Evaluate with RMSE + MAE + calibration plot (predicted vs true).
+
+### Starter model shape
+- Input: 1024/2048 fingerprint bits
+- Hidden: `[512, 256]`
+- Output: `1`
+
+### Deliverables
+- Training script
+- `results.json` with metrics
+- Short note: where model underfits/overfits
+
+---
+
+## Exercise 2 — Multitask MLP (missing labels)
+
+### Goal
+Train a shared trunk with multiple task heads (or one multi-output head) and masked loss.
+
+### Recommended datasets
+- **Public benchmark option:** MoleculeNet multitask datasets (e.g., Tox21, SIDER).
+- **Local project-style option:** create synthetic multitask labels from ESOL + auxiliary tasks (e.g., binned solubility class, scaffold flag).
+
+### What to implement
+1. `y` as shape `[batch, n_tasks]` and `mask` for missing labels.
+2. Shared encoder MLP + output head(s).
+3. Masked loss (`BCEWithLogitsLoss` or `MSELoss` per task with mask).
+4. Per-task metrics + macro average.
+
+### Deliverables
+- Multitask training loop
+- Per-task dashboard table
+- Analysis: when multitask helps vs hurts single-task
+
+---
+
+## Exercise 3 — GCN/MPNN on molecular graphs
+
+### Goal
+Predict molecular properties directly from graph structure instead of fixed descriptors.
+
+### Recommended datasets
+- **Local option:** ESOL from `src/data/esol/raw/delaney-processed.csv`
+- **Public option:** QM9 (for quantum properties), FreeSolv, Lipophilicity
+
+### What to implement
+1. Convert molecules into graph objects (`x`, `edge_index`, optional `edge_attr`).
+2. Build 2-4 message-passing layers + global pooling.
+3. Compare against Exercise 1 MLP baseline on the same split.
+4. Add scaffold split to test generalization.
+
+### Deliverables
+- Graph featurization pipeline
+- GCN/MPNN model
+- Fair comparison report (same split and metric)
+
+---
+
+## Exercise 4 — SMILES LSTM baseline
+
+### Goal
+Treat molecules as token sequences and learn sequence-based representations.
+
+### Recommended datasets
+- ESOL (local) or any small property dataset with SMILES + scalar target
+
+### What to implement
+1. SMILES tokenizer (char-level is enough to start).
+2. Embedding + LSTM encoder + regression/classification head.
+3. Padding + packed sequence handling.
+4. Error analysis by sequence length and token rarity.
+
+### Deliverables
+- Tokenizer/vocabulary stats
+- LSTM training script
+- Comparison vs MLP and GCN
+
+---
+
+## Exercise 5 — 3D CNN for structure-based scoring (advanced)
+
+### Goal
+Predict binding affinity or binder/non-binder from voxelized protein-ligand neighborhoods.
+
+### Recommended datasets
+- **Public options:** PDBbind-derived curated sets (small cleaned subsets for starter runs).
+- **Practical note:** start with a tiny subset first due to preprocessing cost.
+
+### What to implement
+1. Voxelizer that converts atom environments to a 3D tensor.
+2. Small 3D CNN + MLP head.
+3. Data augmentation (random rotations/translations).
+4. Benchmark against simple docking-score-only baseline.
+
+### Deliverables
+- Voxelization script
+- 3D CNN training run on a toy subset
+- Failure cases (pose sensitivity, noisy labels)
+
+---
+
+## Proposed capstone projects
+
+## Project A — Baseline-to-Graph comparison on one endpoint
+
+### Plan
+1. Train fingerprint MLP (Exercise 1).
+2. Train GCN/MPNN (Exercise 3) on identical train/val/test split.
+3. Compare performance + inference speed + robustness to scaffold split.
+
+### Why this is strong
+- Gives a realistic chemistry ML workflow: simple baseline first, then graph model.
+- Produces a clean story for interviews or research proposals.
+
+---
+
+## Project B — Multitask property panel
+
+### Plan
+1. Build multitask MLP with masking (Exercise 2).
+2. Add uncertainty estimation (MC dropout or deep ensembles).
+3. Produce a ranked candidate list with confidence filtering.
+
+### Why this is strong
+- Mirrors real medicinal chemistry settings with sparse labels across endpoints.
+
+---
+
+## Project C — Polymer extension track
+
+### Plan
+1. Start from local polymer archive: `src/data/neurips-open-polymer-prediction-2025.zip`.
+2. Build a property predictor pipeline (tabular baseline -> GNN if graph data available).
+3. Add domain split by chemistry family to evaluate out-of-domain behavior.
+
+### Why this is strong
+- Directly aligned with modern materials/polymer property prediction workflows.
+
+---
+
+## Sample dataset menu (what to use right now)
+
+## Immediately available in this repo
+
+1. `src/data/esol/raw/delaney-processed.csv`
+   - Best for Exercises 1, 3, and 4.
+2. `src/data/neurips-open-polymer-prediction-2025.zip`
+   - Best for Project C and advanced custom tasks.
+
+## Good external datasets to add next
+
+1. **MoleculeNet**: ESOL, FreeSolv, Lipophilicity, Tox21, SIDER, ClinTox, HIV
+2. **QM9**: quantum property regression
+3. **PDBbind (curated subset)**: 3D protein-ligand scoring
+
+---
+
+## Suggested 4-week execution plan
+
+- **Week 1:** Exercise 1 (MLP baseline) + robust evaluation template
+- **Week 2:** Exercise 3 (GCN/MPNN) + apples-to-apples comparison
+- **Week 3:** Exercise 2 (multitask) + missing-label masking
+- **Week 4:** Exercise 4 (SMILES LSTM) or small Exercise 5 prototype
+
+---
+
+## Minimal success criteria per exercise
+
+- Reproducible run (fixed seeds)
+- Clear split strategy (random and scaffold if possible)
+- At least one ablation (depth, hidden size, dropout, or featurization)
+- Save model checkpoints and prediction CSVs
+- 5-10 bullet error analysis


### PR DESCRIPTION
### Motivation

- Extend the PyTorchlings exercise track with a short chemistry-to-3D progression so learners can practice fingerprint baselines, multitask masking, graph message passing, sequence LSTM encoding, and 3D CNN volumetric scoring. 
- Surface a compact interview-focused chemistry exercise pack to standardize candidate / take-home tasks and suggested datasets. 

### Description

- Add exercises 74–78 under `pytorchlings/exercises/`: `74_fingerprint_qsar_mlp` (fingerprint MLP), `75_multitask_qsar_masked` (masked multitask MLP), `76_molecular_graph_message_passing` (hand-rolled message passing regressor), `77_smiles_lstm_property` (SMILES LSTM encoder/regressor), and `78_protein_ligand_3dcnn` (minimal 3D CNN scorer). 
- Update `pytorchlings/EXERCISES.md` and `pytorchlings/README.md` to list the new chemistry progression exercises. 
- Add `src/pytorch_practice/interview_exercises/chemistry_nn_exercises.md` with a stepwise set of chemistry NN exercises, datasets, deliverables, and suggested capstone projects, and update the interview exercises README to reference it. 

### Testing

- Ran smoke checks by executing each new exercise script's `__main__` (each file contains small asserts) and all scripts printed their success message indicating the basic forward/shape checks passed. 
- Ran a syntax/bytecode verification using `python -m compileall pytorchlings/exercises pytorchlings/solutions` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd163ca2b8832eb5f6e8d9b97c8164)