### PR TITLE
Add progressive pytorchlings architecture build-up exercises (79–82)

### DIFF
--- a/pytorchlings/EXERCISES.md
+++ b/pytorchlings/EXERCISES.md
@@ -90,3 +90,8 @@
 | 81 | PyTorch | Ligand-protein cross-attention fusion | `exercises/81_cross_attention_fusion/ligand_protein_cross_attention.py` | `solutions/81_ligand_protein_cross_attention.py` |
 | 82 | PyTorch | Multimodal property model with uncertainty head | `exercises/82_multimodal_uncertainty_head/multimodal_property_with_uncertainty.py` | `solutions/82_multimodal_property_with_uncertainty.py` |
 
+
+| 83 | PyTorch | Residual MLP backbone from earlier building blocks | `exercises/83_residual_mlp_backbone/residual_mlp_backbone.py` | `solutions/83_residual_mlp_backbone.py` |
+| 84 | PyTorch | CNN-Transformer hybrid encoder | `exercises/84_cnn_transformer_hybrid/cnn_transformer_hybrid.py` | `solutions/84_cnn_transformer_hybrid.py` |
+| 85 | PyTorch | Graph-sequence co-encoder with bidirectional cross-attention | `exercises/85_graph_sequence_coencoder/graph_sequence_coencoder.py` | `solutions/85_graph_sequence_coencoder.py` |
+| 86 | PyTorch | Mixture-of-Experts multimodal router | `exercises/86_moe_multimodal_router/moe_multimodal_router.py` | `solutions/86_moe_multimodal_router.py` |

--- a/pytorchlings/EXERCISES.md
+++ b/pytorchlings/EXERCISES.md
@@ -85,4 +85,8 @@
 | 76 | PyTorch | Molecular graph message passing (from scratch) | `exercises/76_molecular_graph_message_passing/molecular_graph_message_passing.py` | `N/A (exercise scaffold)` |
 | 77 | PyTorch | SMILES LSTM property prediction scaffold | `exercises/77_smiles_lstm_property/smiles_lstm_property.py` | `N/A (exercise scaffold)` |
 | 78 | PyTorch | Protein-ligand 3D CNN scoring scaffold | `exercises/78_protein_ligand_3dcnn/protein_ligand_3dcnn.py` | `N/A (exercise scaffold)` |
+| 79 | PyTorch | Hybrid fingerprint+graph fusion architecture | `exercises/79_hybrid_fusion_architecture/hybrid_fingerprint_graph_fusion.py` | `solutions/79_hybrid_fingerprint_graph_fusion.py` |
+| 80 | PyTorch | Residual gated MPNN stack | `exercises/80_residual_mpnn_stack/residual_gated_mpnn.py` | `solutions/80_residual_gated_mpnn.py` |
+| 81 | PyTorch | Ligand-protein cross-attention fusion | `exercises/81_cross_attention_fusion/ligand_protein_cross_attention.py` | `solutions/81_ligand_protein_cross_attention.py` |
+| 82 | PyTorch | Multimodal property model with uncertainty head | `exercises/82_multimodal_uncertainty_head/multimodal_property_with_uncertainty.py` | `solutions/82_multimodal_property_with_uncertainty.py` |
 

--- a/pytorchlings/README.md
+++ b/pytorchlings/README.md
@@ -25,6 +25,7 @@ A rustlings-style practice track for **PyTorch** and **PyTorch Geometric (PyG)**
 - Add 62-65 for chemistry-oriented generative modeling, hill-climbing evals, and slice-based scientific error analysis.
 - Add 66-73 for interview-focused research practice: math refresh drills, from-scratch baselines, accelerator-native patterns, RDKit/PyG pipelines, graph-vs-geometry modeling, reproducible training stacks, and ablation reporting.
 - Add 74-78 for chemistry-model progression examples: fingerprint MLP baseline, multitask masking, molecular message passing, SMILES LSTM, and protein-ligand 3D CNN.
+- Continue 79-82 to reuse earlier building blocks in progressively more complex architectures: hybrid fusion, residual MPNNs, cross-attention fusion, and multimodal uncertainty modeling.
 
 ## Quick check command
 
@@ -101,3 +102,13 @@ Exercises 74-78 provide direct hands-on scaffolds matching a practical chemistry
 - Molecular graph message passing and graph-level readout
 - SMILES LSTM sequence modeling
 - 3D CNN scoring on voxelized protein-ligand neighborhoods
+
+
+## Progressive architecture build-up extension
+
+Exercises 79-82 are intentionally cumulative: each task reuses ideas from earlier exercises and composes them into larger systems.
+
+- 79: combine fingerprint and graph encoders into a single fusion predictor
+- 80: deepen graph models with residual/gated message-passing blocks
+- 81: introduce ligand-protein cross-attention for conditional representation learning
+- 82: merge fingerprint, graph, and sequence streams into a multimodal uncertainty-aware model

--- a/pytorchlings/README.md
+++ b/pytorchlings/README.md
@@ -26,6 +26,7 @@ A rustlings-style practice track for **PyTorch** and **PyTorch Geometric (PyG)**
 - Add 66-73 for interview-focused research practice: math refresh drills, from-scratch baselines, accelerator-native patterns, RDKit/PyG pipelines, graph-vs-geometry modeling, reproducible training stacks, and ablation reporting.
 - Add 74-78 for chemistry-model progression examples: fingerprint MLP baseline, multitask masking, molecular message passing, SMILES LSTM, and protein-ligand 3D CNN.
 - Continue 79-82 to reuse earlier building blocks in progressively more complex architectures: hybrid fusion, residual MPNNs, cross-attention fusion, and multimodal uncertainty modeling.
+- Extend 83-86 for deeper architectural composition in the pytorchlings folder: residual MLP backbones, CNN-transformer hybrids, graph-sequence co-encoders, and multimodal MoE routing.
 
 ## Quick check command
 
@@ -112,3 +113,13 @@ Exercises 79-82 are intentionally cumulative: each task reuses ideas from earlie
 - 80: deepen graph models with residual/gated message-passing blocks
 - 81: introduce ligand-protein cross-attention for conditional representation learning
 - 82: merge fingerprint, graph, and sequence streams into a multimodal uncertainty-aware model
+
+
+## Advanced composition extension (pytorchlings folder)
+
+Exercises 83-86 continue the same cumulative pattern and explicitly push learners to compose earlier templates into larger architectures:
+
+- 83: residual MLP backbone design for stable depth scaling
+- 84: CNN feature extraction fused with transformer token mixing
+- 85: graph-sequence co-encoding with bidirectional cross-attention
+- 86: multimodal Mixture-of-Experts routing for specialization

--- a/pytorchlings/exercises/79_hybrid_fusion_architecture/hybrid_fingerprint_graph_fusion.py
+++ b/pytorchlings/exercises/79_hybrid_fusion_architecture/hybrid_fingerprint_graph_fusion.py
@@ -1,0 +1,82 @@
+"""Exercise 79: hybrid fingerprint + graph architecture.
+
+Builds on:
+- Exercise 74 (fingerprint MLP baseline)
+- Exercise 76 (message passing graph encoder)
+
+Goal:
+- encode tabular fingerprint and molecular graph views separately
+- fuse both representations for final prediction
+"""
+
+import torch
+from torch import nn
+
+
+class FingerprintEncoder(nn.Module):
+    def __init__(self, in_dim: int, hidden: int = 128):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(in_dim, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, hidden),
+            nn.ReLU(),
+        )
+
+    def forward(self, x_fp: torch.Tensor) -> torch.Tensor:
+        return self.net(x_fp)
+
+
+class GraphEncoder(nn.Module):
+    def __init__(self, node_dim: int, hidden: int = 128):
+        super().__init__()
+        self.self_lin = nn.Linear(node_dim, hidden)
+        self.neigh_lin = nn.Linear(node_dim, hidden)
+        self.out = nn.Linear(hidden, hidden)
+
+    def forward(self, x_nodes: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        # x_nodes shape: [batch, n_nodes, node_dim]
+        deg = adj.sum(dim=-1, keepdim=True).clamp_min(1.0)
+        neigh_mean = (adj @ x_nodes) / deg
+        h = torch.relu(self.self_lin(x_nodes) + self.neigh_lin(neigh_mean))
+
+        # TODO: replace mean pool with attention or set-transformer readout
+        graph_repr = h.mean(dim=1)
+        return torch.relu(self.out(graph_repr))
+
+
+class HybridFusionRegressor(nn.Module):
+    def __init__(self, fp_dim: int, node_dim: int, hidden: int = 128):
+        super().__init__()
+        self.fp_encoder = FingerprintEncoder(fp_dim, hidden)
+        self.graph_encoder = GraphEncoder(node_dim, hidden)
+        self.head = nn.Sequential(
+            nn.Linear(hidden * 2, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, 1),
+        )
+
+    def forward(self, x_fp: torch.Tensor, x_nodes: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        fp_repr = self.fp_encoder(x_fp)
+        graph_repr = self.graph_encoder(x_nodes, adj)
+        fused = torch.cat([fp_repr, graph_repr], dim=-1)
+        return self.head(fused).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(79)
+    batch, fp_dim, n_nodes, node_dim = 8, 256, 18, 24
+    x_fp = torch.randn(batch, fp_dim)
+    x_nodes = torch.randn(batch, n_nodes, node_dim)
+
+    raw = torch.randint(0, 2, (batch, n_nodes, n_nodes), dtype=torch.float32)
+    adj = torch.triu(raw, diagonal=1)
+    adj = adj + adj.transpose(-1, -2)
+    eye = torch.eye(n_nodes).unsqueeze(0)
+    adj = (adj + eye).clamp(max=1.0)
+
+    model = HybridFusionRegressor(fp_dim=fp_dim, node_dim=node_dim, hidden=64)
+    pred = model(x_fp, x_nodes, adj)
+
+    assert pred.shape == (batch,)
+    print("exercise 79 smoke check passed")

--- a/pytorchlings/exercises/80_residual_mpnn_stack/residual_gated_mpnn.py
+++ b/pytorchlings/exercises/80_residual_mpnn_stack/residual_gated_mpnn.py
@@ -1,0 +1,65 @@
+"""Exercise 80: residual + gated MPNN stack.
+
+Builds on:
+- Exercise 76 (manual message passing)
+- Exercise 79 (fusion design patterns)
+
+Goal:
+- stack message passing blocks with residual updates
+- stabilize deeper graph encoders via gating and normalization
+"""
+
+import torch
+from torch import nn
+
+
+class ResidualMPBlock(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.self_lin = nn.Linear(dim, dim)
+        self.neigh_lin = nn.Linear(dim, dim)
+        self.gate = nn.Linear(dim, dim)
+        self.norm = nn.LayerNorm(dim)
+
+    def forward(self, h: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        deg = adj.sum(dim=-1, keepdim=True).clamp_min(1.0)
+        neigh = (adj @ h) / deg
+        update = torch.tanh(self.self_lin(h) + self.neigh_lin(neigh))
+        mix = torch.sigmoid(self.gate(h))
+
+        # TODO: try pre-norm variant and compare optimization stability
+        out = mix * update + (1.0 - mix) * h
+        return self.norm(out)
+
+
+class ResidualGatedMPNN(nn.Module):
+    def __init__(self, in_dim: int, hidden: int = 96, depth: int = 4):
+        super().__init__()
+        self.input_proj = nn.Linear(in_dim, hidden)
+        self.blocks = nn.ModuleList([ResidualMPBlock(hidden) for _ in range(depth)])
+        self.head = nn.Sequential(nn.Linear(hidden, hidden), nn.ReLU(), nn.Linear(hidden, 1))
+
+    def forward(self, x_nodes: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        h = torch.relu(self.input_proj(x_nodes))
+        for block in self.blocks:
+            h = block(h, adj)
+        graph_repr = h.mean(dim=1)
+        return self.head(graph_repr).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(80)
+    batch, n_nodes, node_dim = 6, 20, 32
+    x_nodes = torch.randn(batch, n_nodes, node_dim)
+
+    a = torch.randint(0, 2, (batch, n_nodes, n_nodes), dtype=torch.float32)
+    adj = torch.triu(a, diagonal=1)
+    adj = adj + adj.transpose(-1, -2)
+    adj = (adj + torch.eye(n_nodes).unsqueeze(0)).clamp(max=1.0)
+
+    model = ResidualGatedMPNN(in_dim=node_dim, hidden=64, depth=5)
+    pred = model(x_nodes, adj)
+
+    assert pred.shape == (batch,)
+    assert torch.isfinite(pred).all()
+    print("exercise 80 smoke check passed")

--- a/pytorchlings/exercises/81_cross_attention_fusion/ligand_protein_cross_attention.py
+++ b/pytorchlings/exercises/81_cross_attention_fusion/ligand_protein_cross_attention.py
@@ -1,0 +1,56 @@
+"""Exercise 81: ligand-protein cross-attention fusion.
+
+Builds on:
+- Exercise 77 (sequence encoders)
+- Exercise 78 (protein-ligand architecture context)
+
+Goal:
+- encode ligand tokens and protein-pocket tokens
+- use cross-attention to condition ligand representation on protein context
+"""
+
+import torch
+from torch import nn
+
+
+class TokenEncoder(nn.Module):
+    def __init__(self, vocab_size: int, d_model: int):
+        super().__init__()
+        self.emb = nn.Embedding(vocab_size, d_model, padding_idx=0)
+        self.ff = nn.Sequential(nn.Linear(d_model, d_model), nn.ReLU())
+
+    def forward(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.ff(self.emb(token_ids))
+
+
+class CrossAttentionScorer(nn.Module):
+    def __init__(self, lig_vocab: int, prot_vocab: int, d_model: int = 64, n_heads: int = 4):
+        super().__init__()
+        self.lig_enc = TokenEncoder(lig_vocab, d_model)
+        self.prot_enc = TokenEncoder(prot_vocab, d_model)
+        self.cross_attn = nn.MultiheadAttention(d_model, n_heads, batch_first=True)
+        self.out = nn.Sequential(nn.Linear(d_model, d_model), nn.ReLU(), nn.Linear(d_model, 1))
+
+    def forward(self, ligand_ids: torch.Tensor, protein_ids: torch.Tensor) -> torch.Tensor:
+        lig = self.lig_enc(ligand_ids)
+        prot = self.prot_enc(protein_ids)
+
+        # ligand queries protein context
+        attended, _ = self.cross_attn(query=lig, key=prot, value=prot)
+
+        # TODO: add padding masks for variable-length batches
+        pooled = attended.mean(dim=1)
+        return self.out(pooled).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(81)
+    bsz, lig_len, prot_len = 5, 24, 40
+    ligand_ids = torch.randint(1, 32, (bsz, lig_len))
+    protein_ids = torch.randint(1, 48, (bsz, prot_len))
+
+    model = CrossAttentionScorer(lig_vocab=32, prot_vocab=48, d_model=64, n_heads=4)
+    pred = model(ligand_ids, protein_ids)
+
+    assert pred.shape == (bsz,)
+    print("exercise 81 smoke check passed")

--- a/pytorchlings/exercises/82_multimodal_uncertainty_head/multimodal_property_with_uncertainty.py
+++ b/pytorchlings/exercises/82_multimodal_uncertainty_head/multimodal_property_with_uncertainty.py
@@ -1,0 +1,89 @@
+"""Exercise 82: multimodal architecture with uncertainty head.
+
+Builds on:
+- Exercise 79 (fingerprint + graph fusion)
+- Exercise 81 (cross-attention fusion)
+
+Goal:
+- combine three modality encoders (fingerprint, graph, sequence)
+- output mean + log-variance for heteroscedastic regression
+"""
+
+import torch
+from torch import nn
+
+
+class MultiModalPropertyModel(nn.Module):
+    def __init__(self, fp_dim: int, node_dim: int, vocab_size: int, hidden: int = 96):
+        super().__init__()
+        self.fp_encoder = nn.Sequential(nn.Linear(fp_dim, hidden), nn.ReLU())
+        self.node_proj = nn.Linear(node_dim, hidden)
+        self.token_emb = nn.Embedding(vocab_size, hidden, padding_idx=0)
+        self.token_attn = nn.MultiheadAttention(hidden, num_heads=4, batch_first=True)
+
+        self.trunk = nn.Sequential(
+            nn.Linear(hidden * 3, hidden * 2),
+            nn.ReLU(),
+            nn.Linear(hidden * 2, hidden),
+            nn.ReLU(),
+        )
+        self.mean_head = nn.Linear(hidden, 1)
+        self.logvar_head = nn.Linear(hidden, 1)
+
+    def encode_graph(self, x_nodes: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        deg = adj.sum(dim=-1, keepdim=True).clamp_min(1.0)
+        neigh_mean = (adj @ x_nodes) / deg
+        h = torch.relu(self.node_proj(0.5 * (x_nodes + neigh_mean)))
+        return h.mean(dim=1)
+
+    def encode_tokens(self, token_ids: torch.Tensor) -> torch.Tensor:
+        tok = self.token_emb(token_ids)
+        attended, _ = self.token_attn(tok, tok, tok)
+
+        # TODO: add attention mask support so padded positions are ignored
+        return attended.mean(dim=1)
+
+    def forward(
+        self,
+        x_fp: torch.Tensor,
+        x_nodes: torch.Tensor,
+        adj: torch.Tensor,
+        token_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        fp_repr = self.fp_encoder(x_fp)
+        graph_repr = self.encode_graph(x_nodes, adj)
+        token_repr = self.encode_tokens(token_ids)
+
+        fused = torch.cat([fp_repr, graph_repr, token_repr], dim=-1)
+        h = self.trunk(fused)
+        mean = self.mean_head(h).squeeze(-1)
+        logvar = self.logvar_head(h).squeeze(-1)
+        return mean, logvar
+
+
+def gaussian_nll(mean: torch.Tensor, logvar: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    inv_var = torch.exp(-logvar)
+    return 0.5 * torch.mean(logvar + (target - mean) ** 2 * inv_var)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(82)
+    batch, fp_dim, n_nodes, node_dim, seq_len = 4, 256, 14, 32, 22
+    x_fp = torch.randn(batch, fp_dim)
+    x_nodes = torch.randn(batch, n_nodes, node_dim)
+    token_ids = torch.randint(1, 30, (batch, seq_len))
+
+    a = torch.randint(0, 2, (batch, n_nodes, n_nodes), dtype=torch.float32)
+    adj = torch.triu(a, diagonal=1)
+    adj = adj + adj.transpose(-1, -2)
+    adj = (adj + torch.eye(n_nodes).unsqueeze(0)).clamp(max=1.0)
+
+    target = torch.randn(batch)
+    model = MultiModalPropertyModel(fp_dim=fp_dim, node_dim=node_dim, vocab_size=30, hidden=64)
+    mean, logvar = model(x_fp, x_nodes, adj, token_ids)
+    loss = gaussian_nll(mean, logvar, target)
+
+    assert mean.shape == (batch,)
+    assert logvar.shape == (batch,)
+    assert torch.isfinite(loss)
+    print("exercise 82 smoke check passed")

--- a/pytorchlings/exercises/83_residual_mlp_backbone/residual_mlp_backbone.py
+++ b/pytorchlings/exercises/83_residual_mlp_backbone/residual_mlp_backbone.py
@@ -1,0 +1,53 @@
+"""Exercise 83: residual MLP backbone from earlier PyTorch blocks.
+
+Builds on:
+- Exercise 02 (MLP construction)
+- Exercise 42 (initialization strategy)
+- Exercise 43 (gradient-stable training loops)
+
+Goal:
+- refactor a plain MLP into residual pre-norm blocks
+- keep the model easy to scale in depth without rewriting code
+"""
+
+import torch
+from torch import nn
+
+
+class ResidualMLPBlock(nn.Module):
+    def __init__(self, dim: int, dropout: float = 0.1):
+        super().__init__()
+        self.norm = nn.LayerNorm(dim)
+        self.ff = nn.Sequential(
+            nn.Linear(dim, dim * 2),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(dim * 2, dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # TODO: compare this pre-norm residual with a post-norm variant
+        return x + self.ff(self.norm(x))
+
+
+class ResidualMLPRegressor(nn.Module):
+    def __init__(self, in_dim: int, hidden: int = 128, depth: int = 4):
+        super().__init__()
+        self.stem = nn.Sequential(nn.Linear(in_dim, hidden), nn.ReLU())
+        self.blocks = nn.ModuleList([ResidualMLPBlock(hidden) for _ in range(depth)])
+        self.head = nn.Linear(hidden, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.stem(x)
+        for blk in self.blocks:
+            h = blk(h)
+        return self.head(h).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(83)
+    x = torch.randn(10, 256)
+    model = ResidualMLPRegressor(in_dim=256, hidden=96, depth=3)
+    y = model(x)
+    assert y.shape == (10,)
+    print("exercise 83 smoke check passed")

--- a/pytorchlings/exercises/84_cnn_transformer_hybrid/cnn_transformer_hybrid.py
+++ b/pytorchlings/exercises/84_cnn_transformer_hybrid/cnn_transformer_hybrid.py
@@ -1,0 +1,49 @@
+"""Exercise 84: CNN -> Transformer hybrid encoder.
+
+Builds on:
+- Exercise 05 (CNN feature extraction)
+- Exercise 18 (transformer block)
+
+Goal:
+- turn 2D feature maps into token sequences
+- apply transformer encoding before global pooling
+"""
+
+import torch
+from torch import nn
+
+
+class CNNTransformerHybrid(nn.Module):
+    def __init__(self, in_channels: int = 3, d_model: int = 64, n_heads: int = 4):
+        super().__init__()
+        self.cnn = nn.Sequential(
+            nn.Conv2d(in_channels, 32, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.MaxPool2d(2),
+            nn.Conv2d(32, d_model, kernel_size=3, padding=1),
+            nn.ReLU(),
+        )
+        self.encoder = nn.TransformerEncoder(
+            nn.TransformerEncoderLayer(d_model=d_model, nhead=n_heads, batch_first=True),
+            num_layers=2,
+        )
+        self.head = nn.Linear(d_model, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        fmap = self.cnn(x)  # [B, C, H, W]
+        b, c, h, w = fmap.shape
+        tokens = fmap.permute(0, 2, 3, 1).reshape(b, h * w, c)
+
+        # TODO: add positional encodings so the transformer keeps spatial context
+        z = self.encoder(tokens)
+        pooled = z.mean(dim=1)
+        return self.head(pooled).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(84)
+    x = torch.randn(6, 3, 32, 32)
+    model = CNNTransformerHybrid(in_channels=3, d_model=64, n_heads=4)
+    y = model(x)
+    assert y.shape == (6,)
+    print("exercise 84 smoke check passed")

--- a/pytorchlings/exercises/85_graph_sequence_coencoder/graph_sequence_coencoder.py
+++ b/pytorchlings/exercises/85_graph_sequence_coencoder/graph_sequence_coencoder.py
@@ -1,0 +1,59 @@
+"""Exercise 85: graph + sequence co-encoder.
+
+Builds on:
+- Exercise 76 (graph message passing)
+- Exercise 77 (sequence encoding)
+- Exercise 81 (cross-attention)
+
+Goal:
+- encode graph nodes and sequence tokens in parallel
+- perform bidirectional cross-attention before final fusion
+"""
+
+import torch
+from torch import nn
+
+
+class GraphSequenceCoEncoder(nn.Module):
+    def __init__(self, node_dim: int, vocab_size: int, hidden: int = 64):
+        super().__init__()
+        self.node_proj = nn.Linear(node_dim, hidden)
+        self.token_emb = nn.Embedding(vocab_size, hidden, padding_idx=0)
+
+        self.seq_to_graph = nn.MultiheadAttention(hidden, num_heads=4, batch_first=True)
+        self.graph_to_seq = nn.MultiheadAttention(hidden, num_heads=4, batch_first=True)
+
+        self.head = nn.Sequential(nn.Linear(hidden * 2, hidden), nn.ReLU(), nn.Linear(hidden, 1))
+
+    def encode_graph(self, x_nodes: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        deg = adj.sum(dim=-1, keepdim=True).clamp_min(1.0)
+        neigh = (adj @ x_nodes) / deg
+        return torch.relu(self.node_proj(0.5 * (x_nodes + neigh)))
+
+    def forward(self, x_nodes: torch.Tensor, adj: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:
+        g = self.encode_graph(x_nodes, adj)
+        s = self.token_emb(token_ids)
+
+        s_ctx, _ = self.seq_to_graph(query=s, key=g, value=g)
+        g_ctx, _ = self.graph_to_seq(query=g, key=s, value=s)
+
+        # TODO: add masks and weighted readouts per modality
+        fused = torch.cat([s_ctx.mean(dim=1), g_ctx.mean(dim=1)], dim=-1)
+        return self.head(fused).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(85)
+    bsz, n_nodes, node_dim, seq_len = 4, 15, 20, 18
+    x_nodes = torch.randn(bsz, n_nodes, node_dim)
+    token_ids = torch.randint(1, 25, (bsz, seq_len))
+
+    a = torch.randint(0, 2, (bsz, n_nodes, n_nodes), dtype=torch.float32)
+    adj = torch.triu(a, diagonal=1)
+    adj = adj + adj.transpose(-1, -2)
+    adj = (adj + torch.eye(n_nodes).unsqueeze(0)).clamp(max=1.0)
+
+    model = GraphSequenceCoEncoder(node_dim=node_dim, vocab_size=25, hidden=64)
+    y = model(x_nodes, adj, token_ids)
+    assert y.shape == (bsz,)
+    print("exercise 85 smoke check passed")

--- a/pytorchlings/exercises/86_moe_multimodal_router/moe_multimodal_router.py
+++ b/pytorchlings/exercises/86_moe_multimodal_router/moe_multimodal_router.py
@@ -1,0 +1,50 @@
+"""Exercise 86: Mixture-of-Experts multimodal router.
+
+Builds on:
+- Exercise 82 (multimodal fusion + uncertainty)
+- Exercise 83 (residual MLP backbones)
+- Exercise 85 (co-encoding modalities)
+
+Goal:
+- route fused representations through multiple expert heads
+- learn soft expert assignments and aggregate predictions
+"""
+
+import torch
+from torch import nn
+
+
+class MoEMultimodalRegressor(nn.Module):
+    def __init__(self, in_dim: int, hidden: int = 128, n_experts: int = 3):
+        super().__init__()
+        self.trunk = nn.Sequential(
+            nn.Linear(in_dim, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, hidden),
+            nn.ReLU(),
+        )
+        self.router = nn.Linear(hidden, n_experts)
+        self.experts = nn.ModuleList([nn.Sequential(nn.Linear(hidden, hidden), nn.ReLU(), nn.Linear(hidden, 1)) for _ in range(n_experts)])
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        h = self.trunk(x)
+        gate_logits = self.router(h)
+        weights = torch.softmax(gate_logits, dim=-1)
+
+        expert_preds = torch.cat([expert(h) for expert in self.experts], dim=-1)
+
+        # TODO: add entropy regularization term for stable expert utilization
+        pred = (weights * expert_preds).sum(dim=-1)
+        return pred, weights
+
+
+if __name__ == "__main__":
+    torch.manual_seed(86)
+    x = torch.randn(12, 192)
+    model = MoEMultimodalRegressor(in_dim=192, hidden=96, n_experts=4)
+    pred, weights = model(x)
+
+    assert pred.shape == (12,)
+    assert weights.shape == (12, 4)
+    assert torch.allclose(weights.sum(dim=-1), torch.ones(12), atol=1e-5)
+    print("exercise 86 smoke check passed")

--- a/pytorchlings/solutions/79_hybrid_fingerprint_graph_fusion.py
+++ b/pytorchlings/solutions/79_hybrid_fingerprint_graph_fusion.py
@@ -1,0 +1,71 @@
+"""Solution 79: hybrid fingerprint + graph architecture."""
+
+import torch
+from torch import nn
+
+
+class FingerprintEncoder(nn.Module):
+    def __init__(self, in_dim: int, hidden: int = 128):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(in_dim, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, hidden),
+            nn.ReLU(),
+        )
+
+    def forward(self, x_fp: torch.Tensor) -> torch.Tensor:
+        return self.net(x_fp)
+
+
+class GraphEncoder(nn.Module):
+    def __init__(self, node_dim: int, hidden: int = 128):
+        super().__init__()
+        self.self_lin = nn.Linear(node_dim, hidden)
+        self.neigh_lin = nn.Linear(node_dim, hidden)
+        self.gate = nn.Linear(hidden, hidden)
+        self.out = nn.Linear(hidden, hidden)
+
+    def forward(self, x_nodes: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        deg = adj.sum(dim=-1, keepdim=True).clamp_min(1.0)
+        neigh_mean = (adj @ x_nodes) / deg
+        h = torch.relu(self.self_lin(x_nodes) + self.neigh_lin(neigh_mean))
+
+        score = torch.sigmoid(self.gate(h))
+        graph_repr = (score * h).sum(dim=1) / score.sum(dim=1).clamp_min(1e-6)
+        return torch.relu(self.out(graph_repr))
+
+
+class HybridFusionRegressor(nn.Module):
+    def __init__(self, fp_dim: int, node_dim: int, hidden: int = 128):
+        super().__init__()
+        self.fp_encoder = FingerprintEncoder(fp_dim, hidden)
+        self.graph_encoder = GraphEncoder(node_dim, hidden)
+        self.head = nn.Sequential(
+            nn.Linear(hidden * 2, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, 1),
+        )
+
+    def forward(self, x_fp: torch.Tensor, x_nodes: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        fp_repr = self.fp_encoder(x_fp)
+        graph_repr = self.graph_encoder(x_nodes, adj)
+        fused = torch.cat([fp_repr, graph_repr], dim=-1)
+        return self.head(fused).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(79)
+    batch, fp_dim, n_nodes, node_dim = 8, 256, 18, 24
+    x_fp = torch.randn(batch, fp_dim)
+    x_nodes = torch.randn(batch, n_nodes, node_dim)
+    raw = torch.randint(0, 2, (batch, n_nodes, n_nodes), dtype=torch.float32)
+    adj = torch.triu(raw, diagonal=1)
+    adj = adj + adj.transpose(-1, -2)
+    adj = (adj + torch.eye(n_nodes).unsqueeze(0)).clamp(max=1.0)
+
+    model = HybridFusionRegressor(fp_dim=fp_dim, node_dim=node_dim, hidden=64)
+    pred = model(x_fp, x_nodes, adj)
+
+    assert pred.shape == (batch,)
+    print("solution 79 smoke check passed")

--- a/pytorchlings/solutions/80_residual_gated_mpnn.py
+++ b/pytorchlings/solutions/80_residual_gated_mpnn.py
@@ -1,0 +1,56 @@
+"""Solution 80: residual + gated MPNN stack."""
+
+import torch
+from torch import nn
+
+
+class ResidualMPBlock(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.norm = nn.LayerNorm(dim)
+        self.self_lin = nn.Linear(dim, dim)
+        self.neigh_lin = nn.Linear(dim, dim)
+        self.gate = nn.Linear(dim, dim)
+        self.ff = nn.Sequential(nn.Linear(dim, dim * 2), nn.GELU(), nn.Linear(dim * 2, dim))
+
+    def forward(self, h: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        z = self.norm(h)
+        deg = adj.sum(dim=-1, keepdim=True).clamp_min(1.0)
+        neigh = (adj @ z) / deg
+        update = torch.tanh(self.self_lin(z) + self.neigh_lin(neigh))
+        mix = torch.sigmoid(self.gate(z))
+        h = mix * update + (1.0 - mix) * h
+        return h + self.ff(self.norm(h))
+
+
+class ResidualGatedMPNN(nn.Module):
+    def __init__(self, in_dim: int, hidden: int = 96, depth: int = 4):
+        super().__init__()
+        self.input_proj = nn.Linear(in_dim, hidden)
+        self.blocks = nn.ModuleList([ResidualMPBlock(hidden) for _ in range(depth)])
+        self.readout = nn.Sequential(nn.Linear(hidden, hidden), nn.ReLU())
+        self.head = nn.Linear(hidden, 1)
+
+    def forward(self, x_nodes: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        h = torch.relu(self.input_proj(x_nodes))
+        for block in self.blocks:
+            h = block(h, adj)
+        graph_repr = self.readout(h).mean(dim=1)
+        return self.head(graph_repr).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(80)
+    batch, n_nodes, node_dim = 6, 20, 32
+    x_nodes = torch.randn(batch, n_nodes, node_dim)
+    a = torch.randint(0, 2, (batch, n_nodes, n_nodes), dtype=torch.float32)
+    adj = torch.triu(a, diagonal=1)
+    adj = adj + adj.transpose(-1, -2)
+    adj = (adj + torch.eye(n_nodes).unsqueeze(0)).clamp(max=1.0)
+
+    model = ResidualGatedMPNN(in_dim=node_dim, hidden=64, depth=5)
+    pred = model(x_nodes, adj)
+
+    assert pred.shape == (batch,)
+    assert torch.isfinite(pred).all()
+    print("solution 80 smoke check passed")

--- a/pytorchlings/solutions/81_ligand_protein_cross_attention.py
+++ b/pytorchlings/solutions/81_ligand_protein_cross_attention.py
@@ -1,0 +1,56 @@
+"""Solution 81: ligand-protein cross-attention fusion."""
+
+import torch
+from torch import nn
+
+
+class TokenEncoder(nn.Module):
+    def __init__(self, vocab_size: int, d_model: int):
+        super().__init__()
+        self.emb = nn.Embedding(vocab_size, d_model, padding_idx=0)
+        self.ff = nn.Sequential(nn.Linear(d_model, d_model), nn.GELU())
+
+    def forward(self, token_ids: torch.Tensor) -> torch.Tensor:
+        return self.ff(self.emb(token_ids))
+
+
+class CrossAttentionScorer(nn.Module):
+    def __init__(self, lig_vocab: int, prot_vocab: int, d_model: int = 64, n_heads: int = 4):
+        super().__init__()
+        self.lig_enc = TokenEncoder(lig_vocab, d_model)
+        self.prot_enc = TokenEncoder(prot_vocab, d_model)
+        self.cross_attn = nn.MultiheadAttention(d_model, n_heads, batch_first=True)
+        self.out = nn.Sequential(nn.Linear(d_model, d_model), nn.ReLU(), nn.Linear(d_model, 1))
+
+    def forward(
+        self,
+        ligand_ids: torch.Tensor,
+        protein_ids: torch.Tensor,
+        protein_pad_mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        lig = self.lig_enc(ligand_ids)
+        prot = self.prot_enc(protein_ids)
+        attended, _ = self.cross_attn(
+            query=lig,
+            key=prot,
+            value=prot,
+            key_padding_mask=protein_pad_mask,
+        )
+
+        pooled = attended.mean(dim=1)
+        return self.out(pooled).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(81)
+    bsz, lig_len, prot_len = 5, 24, 40
+    ligand_ids = torch.randint(1, 32, (bsz, lig_len))
+    protein_ids = torch.randint(1, 48, (bsz, prot_len))
+    protein_ids[0, -5:] = 0
+    protein_pad_mask = protein_ids.eq(0)
+
+    model = CrossAttentionScorer(lig_vocab=32, prot_vocab=48, d_model=64, n_heads=4)
+    pred = model(ligand_ids, protein_ids, protein_pad_mask=protein_pad_mask)
+
+    assert pred.shape == (bsz,)
+    print("solution 81 smoke check passed")

--- a/pytorchlings/solutions/82_multimodal_property_with_uncertainty.py
+++ b/pytorchlings/solutions/82_multimodal_property_with_uncertainty.py
@@ -1,0 +1,84 @@
+"""Solution 82: multimodal architecture with uncertainty head."""
+
+import torch
+from torch import nn
+
+
+class MultiModalPropertyModel(nn.Module):
+    def __init__(self, fp_dim: int, node_dim: int, vocab_size: int, hidden: int = 96):
+        super().__init__()
+        self.fp_encoder = nn.Sequential(nn.Linear(fp_dim, hidden), nn.ReLU())
+        self.node_proj = nn.Linear(node_dim, hidden)
+        self.token_emb = nn.Embedding(vocab_size, hidden, padding_idx=0)
+        self.token_attn = nn.MultiheadAttention(hidden, num_heads=4, batch_first=True)
+
+        self.trunk = nn.Sequential(
+            nn.Linear(hidden * 3, hidden * 2),
+            nn.ReLU(),
+            nn.Linear(hidden * 2, hidden),
+            nn.ReLU(),
+        )
+        self.mean_head = nn.Linear(hidden, 1)
+        self.logvar_head = nn.Linear(hidden, 1)
+
+    def encode_graph(self, x_nodes: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        deg = adj.sum(dim=-1, keepdim=True).clamp_min(1.0)
+        neigh_mean = (adj @ x_nodes) / deg
+        h = torch.relu(self.node_proj(0.5 * (x_nodes + neigh_mean)))
+        return h.mean(dim=1)
+
+    def encode_tokens(self, token_ids: torch.Tensor) -> torch.Tensor:
+        tok = self.token_emb(token_ids)
+        pad_mask = token_ids.eq(0)
+        attended, _ = self.token_attn(tok, tok, tok, key_padding_mask=pad_mask)
+
+        valid = (~pad_mask).unsqueeze(-1)
+        summed = (attended * valid).sum(dim=1)
+        denom = valid.sum(dim=1).clamp_min(1)
+        return summed / denom
+
+    def forward(
+        self,
+        x_fp: torch.Tensor,
+        x_nodes: torch.Tensor,
+        adj: torch.Tensor,
+        token_ids: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        fp_repr = self.fp_encoder(x_fp)
+        graph_repr = self.encode_graph(x_nodes, adj)
+        token_repr = self.encode_tokens(token_ids)
+
+        fused = torch.cat([fp_repr, graph_repr, token_repr], dim=-1)
+        h = self.trunk(fused)
+        mean = self.mean_head(h).squeeze(-1)
+        logvar = self.logvar_head(h).squeeze(-1).clamp(min=-6.0, max=6.0)
+        return mean, logvar
+
+
+def gaussian_nll(mean: torch.Tensor, logvar: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
+    inv_var = torch.exp(-logvar)
+    return 0.5 * torch.mean(logvar + (target - mean) ** 2 * inv_var)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(82)
+    batch, fp_dim, n_nodes, node_dim, seq_len = 4, 256, 14, 32, 22
+    x_fp = torch.randn(batch, fp_dim)
+    x_nodes = torch.randn(batch, n_nodes, node_dim)
+    token_ids = torch.randint(1, 30, (batch, seq_len))
+    token_ids[0, -3:] = 0
+
+    a = torch.randint(0, 2, (batch, n_nodes, n_nodes), dtype=torch.float32)
+    adj = torch.triu(a, diagonal=1)
+    adj = adj + adj.transpose(-1, -2)
+    adj = (adj + torch.eye(n_nodes).unsqueeze(0)).clamp(max=1.0)
+
+    target = torch.randn(batch)
+    model = MultiModalPropertyModel(fp_dim=fp_dim, node_dim=node_dim, vocab_size=30, hidden=64)
+    mean, logvar = model(x_fp, x_nodes, adj, token_ids)
+    loss = gaussian_nll(mean, logvar, target)
+
+    assert mean.shape == (batch,)
+    assert logvar.shape == (batch,)
+    assert torch.isfinite(loss)
+    print("solution 82 smoke check passed")

--- a/pytorchlings/solutions/83_residual_mlp_backbone.py
+++ b/pytorchlings/solutions/83_residual_mlp_backbone.py
@@ -1,0 +1,43 @@
+"""Solution 83: residual MLP backbone."""
+
+import torch
+from torch import nn
+
+
+class ResidualMLPBlock(nn.Module):
+    def __init__(self, dim: int, dropout: float = 0.1):
+        super().__init__()
+        self.norm = nn.LayerNorm(dim)
+        self.ff = nn.Sequential(
+            nn.Linear(dim, dim * 2),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(dim * 2, dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.ff(self.norm(x))
+
+
+class ResidualMLPRegressor(nn.Module):
+    def __init__(self, in_dim: int, hidden: int = 128, depth: int = 4):
+        super().__init__()
+        self.stem = nn.Sequential(nn.Linear(in_dim, hidden), nn.ReLU())
+        self.blocks = nn.ModuleList([ResidualMLPBlock(hidden) for _ in range(depth)])
+        self.out_norm = nn.LayerNorm(hidden)
+        self.head = nn.Linear(hidden, 1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.stem(x)
+        for blk in self.blocks:
+            h = blk(h)
+        return self.head(self.out_norm(h)).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(83)
+    x = torch.randn(10, 256)
+    model = ResidualMLPRegressor(in_dim=256, hidden=96, depth=3)
+    y = model(x)
+    assert y.shape == (10,)
+    print("solution 83 smoke check passed")

--- a/pytorchlings/solutions/84_cnn_transformer_hybrid.py
+++ b/pytorchlings/solutions/84_cnn_transformer_hybrid.py
@@ -1,0 +1,56 @@
+"""Solution 84: CNN -> Transformer hybrid encoder."""
+
+import torch
+from torch import nn
+
+
+class CNNTransformerHybrid(nn.Module):
+    def __init__(self, in_channels: int = 3, d_model: int = 64, n_heads: int = 4):
+        super().__init__()
+        self.cnn = nn.Sequential(
+            nn.Conv2d(in_channels, 32, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.MaxPool2d(2),
+            nn.Conv2d(32, d_model, kernel_size=3, padding=1),
+            nn.ReLU(),
+        )
+        self.encoder = nn.TransformerEncoder(
+            nn.TransformerEncoderLayer(d_model=d_model, nhead=n_heads, batch_first=True),
+            num_layers=2,
+        )
+        self.head = nn.Linear(d_model, 1)
+
+    def sinusoidal_2d_pos(self, h: int, w: int, d_model: int, device: torch.device) -> torch.Tensor:
+        y = torch.arange(h, device=device).float().unsqueeze(1)
+        x = torch.arange(w, device=device).float().unsqueeze(1)
+        div = torch.exp(torch.arange(0, d_model // 2, 2, device=device).float() * (-torch.log(torch.tensor(10000.0, device=device)) / (d_model // 2)))
+
+        py = torch.zeros(h, d_model // 2, device=device)
+        px = torch.zeros(w, d_model // 2, device=device)
+        py[:, 0::2] = torch.sin(y * div)
+        py[:, 1::2] = torch.cos(y * div)
+        px[:, 0::2] = torch.sin(x * div)
+        px[:, 1::2] = torch.cos(x * div)
+
+        pos = torch.zeros(h, w, d_model, device=device)
+        pos[:, :, : d_model // 2] = py[:, None, :]
+        pos[:, :, d_model // 2 :] = px[None, :, :]
+        return pos.reshape(1, h * w, d_model)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        fmap = self.cnn(x)
+        b, c, h, w = fmap.shape
+        tokens = fmap.permute(0, 2, 3, 1).reshape(b, h * w, c)
+        tokens = tokens + self.sinusoidal_2d_pos(h, w, c, tokens.device)
+        z = self.encoder(tokens)
+        pooled = z.mean(dim=1)
+        return self.head(pooled).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(84)
+    x = torch.randn(6, 3, 32, 32)
+    model = CNNTransformerHybrid(in_channels=3, d_model=64, n_heads=4)
+    y = model(x)
+    assert y.shape == (6,)
+    print("solution 84 smoke check passed")

--- a/pytorchlings/solutions/85_graph_sequence_coencoder.py
+++ b/pytorchlings/solutions/85_graph_sequence_coencoder.py
@@ -1,0 +1,56 @@
+"""Solution 85: graph + sequence co-encoder."""
+
+import torch
+from torch import nn
+
+
+class GraphSequenceCoEncoder(nn.Module):
+    def __init__(self, node_dim: int, vocab_size: int, hidden: int = 64):
+        super().__init__()
+        self.node_proj = nn.Linear(node_dim, hidden)
+        self.token_emb = nn.Embedding(vocab_size, hidden, padding_idx=0)
+
+        self.seq_to_graph = nn.MultiheadAttention(hidden, num_heads=4, batch_first=True)
+        self.graph_to_seq = nn.MultiheadAttention(hidden, num_heads=4, batch_first=True)
+
+        self.head = nn.Sequential(nn.Linear(hidden * 2, hidden), nn.ReLU(), nn.Linear(hidden, 1))
+
+    def encode_graph(self, x_nodes: torch.Tensor, adj: torch.Tensor) -> torch.Tensor:
+        deg = adj.sum(dim=-1, keepdim=True).clamp_min(1.0)
+        neigh = (adj @ x_nodes) / deg
+        return torch.relu(self.node_proj(0.5 * (x_nodes + neigh)))
+
+    def masked_mean(self, x: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
+        valid = (~mask).unsqueeze(-1)
+        return (x * valid).sum(dim=1) / valid.sum(dim=1).clamp_min(1)
+
+    def forward(self, x_nodes: torch.Tensor, adj: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:
+        g = self.encode_graph(x_nodes, adj)
+        s = self.token_emb(token_ids)
+        seq_pad = token_ids.eq(0)
+
+        s_ctx, _ = self.seq_to_graph(query=s, key=g, value=g)
+        g_ctx, _ = self.graph_to_seq(query=g, key=s, value=s, key_padding_mask=seq_pad)
+
+        s_pool = self.masked_mean(s_ctx, seq_pad)
+        g_pool = g_ctx.mean(dim=1)
+        fused = torch.cat([s_pool, g_pool], dim=-1)
+        return self.head(fused).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(85)
+    bsz, n_nodes, node_dim, seq_len = 4, 15, 20, 18
+    x_nodes = torch.randn(bsz, n_nodes, node_dim)
+    token_ids = torch.randint(1, 25, (bsz, seq_len))
+    token_ids[0, -4:] = 0
+
+    a = torch.randint(0, 2, (bsz, n_nodes, n_nodes), dtype=torch.float32)
+    adj = torch.triu(a, diagonal=1)
+    adj = adj + adj.transpose(-1, -2)
+    adj = (adj + torch.eye(n_nodes).unsqueeze(0)).clamp(max=1.0)
+
+    model = GraphSequenceCoEncoder(node_dim=node_dim, vocab_size=25, hidden=64)
+    y = model(x_nodes, adj, token_ids)
+    assert y.shape == (bsz,)
+    print("solution 85 smoke check passed")

--- a/pytorchlings/solutions/86_moe_multimodal_router.py
+++ b/pytorchlings/solutions/86_moe_multimodal_router.py
@@ -1,0 +1,40 @@
+"""Solution 86: Mixture-of-Experts multimodal router."""
+
+import torch
+from torch import nn
+
+
+class MoEMultimodalRegressor(nn.Module):
+    def __init__(self, in_dim: int, hidden: int = 128, n_experts: int = 3):
+        super().__init__()
+        self.trunk = nn.Sequential(
+            nn.Linear(in_dim, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, hidden),
+            nn.ReLU(),
+        )
+        self.router = nn.Linear(hidden, n_experts)
+        self.experts = nn.ModuleList([nn.Sequential(nn.Linear(hidden, hidden), nn.ReLU(), nn.Linear(hidden, 1)) for _ in range(n_experts)])
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        h = self.trunk(x)
+        gate_logits = self.router(h)
+        weights = torch.softmax(gate_logits, dim=-1)
+        expert_preds = torch.cat([expert(h) for expert in self.experts], dim=-1)
+        pred = (weights * expert_preds).sum(dim=-1)
+
+        entropy = -(weights * (weights.clamp_min(1e-8).log())).sum(dim=-1).mean()
+        return pred, weights, entropy
+
+
+if __name__ == "__main__":
+    torch.manual_seed(86)
+    x = torch.randn(12, 192)
+    model = MoEMultimodalRegressor(in_dim=192, hidden=96, n_experts=4)
+    pred, weights, entropy = model(x)
+
+    assert pred.shape == (12,)
+    assert weights.shape == (12, 4)
+    assert torch.allclose(weights.sum(dim=-1), torch.ones(12), atol=1e-5)
+    assert torch.isfinite(entropy)
+    print("solution 86 smoke check passed")


### PR DESCRIPTION
### Motivation
- Provide a small curriculum of cumulative PyTorch exercises that reuse earlier work and step up complexity toward multimodal chemistry architectures.
- Make it easy for learners to compose previously completed building blocks (fingerprint MLPs, message-passing, sequence encoders, cross-attention) into larger systems.

### Description
- Added four new exercises under `pytorchlings/exercises`: `79_hybrid_fusion_architecture`, `80_residual_mpnn_stack`, `81_cross_attention_fusion`, and `82_multimodal_uncertainty_head` with corresponding exercise scripts implementing hybrid fusion, residual gated MPNNs, ligand-protein cross-attention, and a multimodal uncertainty head respectively.
- Added matching solution files under `pytorchlings/solutions` for exercises `79`–`82` that provide reference implementations and improved readout/padding handling.
- Updated the master index `pytorchlings/EXERCISES.md` to register entries `79`–`82` and extended `pytorchlings/README.md` with a `Progressive architecture build-up extension` section describing the cumulative workflow.

### Testing
- Ran `python -m compileall` on the new exercise and solution files, which completed successfully and produced no compile-time errors.
- Attempted to execute the new exercise scripts directly, but execution was blocked in this environment with `ModuleNotFoundError: No module named 'torch'` so runtime smoke checks could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de5ca0adc4832ea26ac0e65b12d358)