### PR TITLE
Add numbered OOP method exercises to py03lings

### DIFF
--- a/py03lings/EXERCISES.md
+++ b/py03lings/EXERCISES.md
@@ -1,16 +1,55 @@
 # Exercise List (with solution mapping)
 
-| # | Topic | Exercise File | Solution File |
-|---|---|---|---|
-| 00 | f-strings and joins | `exercises/00_string_builder/string_builder.py` | `solutions/00_string_builder.py` |
-| 01 | conditionals and loops | `exercises/01_control_flow/control_flow.py` | `solutions/01_control_flow.py` |
-| 02 | list/dict transformations | `exercises/02_collections/collections_ops.py` | `solutions/02_collections_ops.py` |
-| 03 | function defaults and kwargs | `exercises/03_functions/keyword_report.py` | `solutions/03_keyword_report.py` |
+## Core Python fundamentals
 
-| 04 | asyncio basics (`async`/`await`) | `exercises/04_async_sleep/async_sleep.py` | `solutions/04_async_sleep.py` |
-| 05 | async concurrency with `gather` | `exercises/05_async_gather/async_gather.py` | `solutions/05_async_gather.py` |
+1. **00 — f-strings and joins**  
+   Exercise: `exercises/00_string_builder/string_builder.py`  
+   Solution: `solutions/00_string_builder.py`
+2. **01 — conditionals and loops**  
+   Exercise: `exercises/01_control_flow/control_flow.py`  
+   Solution: `solutions/01_control_flow.py`
+3. **02 — list/dict transformations**  
+   Exercise: `exercises/02_collections/collections_ops.py`  
+   Solution: `solutions/02_collections_ops.py`
+4. **03 — function defaults and kwargs**  
+   Exercise: `exercises/03_functions/keyword_report.py`  
+   Solution: `solutions/03_keyword_report.py`
 
-| 06 | dataclasses intro | `exercises/06_dataclasses_intro/student_record.py` | `solutions/06_student_record.py` |
-| 07 | staticmethod factories | `exercises/07_staticmethod_factory/temperature.py` | `solutions/07_temperature.py` |
-| 08 | pydantic model validation | `exercises/08_pydantic_models/order_model.py` | `solutions/08_order_model.py` |
-| 09 | dataclass + staticmethod + pydantic | `exercises/09_dataclass_staticmethod_pydantic/inventory_bridge.py` | `solutions/09_inventory_bridge.py` |
+## Async foundations
+
+5. **04 — asyncio basics (`async`/`await`)**  
+   Exercise: `exercises/04_async_sleep/async_sleep.py`  
+   Solution: `solutions/04_async_sleep.py`
+6. **05 — async concurrency with `gather`**  
+   Exercise: `exercises/05_async_gather/async_gather.py`  
+   Solution: `solutions/05_async_gather.py`
+
+## Data modeling and validation
+
+7. **06 — dataclasses intro**  
+   Exercise: `exercises/06_dataclasses_intro/student_record.py`  
+   Solution: `solutions/06_student_record.py`
+8. **07 — staticmethod factories**  
+   Exercise: `exercises/07_staticmethod_factory/temperature.py`  
+   Solution: `solutions/07_temperature.py`
+9. **08 — pydantic model validation**  
+   Exercise: `exercises/08_pydantic_models/order_model.py`  
+   Solution: `solutions/08_order_model.py`
+10. **09 — dataclass + staticmethod + pydantic**  
+    Exercise: `exercises/09_dataclass_staticmethod_pydantic/inventory_bridge.py`  
+    Solution: `solutions/09_inventory_bridge.py`
+
+## Object orientation methods (basic → advanced)
+
+11. **10 — instance methods and class methods**  
+    Exercise: `exercises/10_instance_class_methods/bank_account.py`  
+    Solution: `solutions/10_instance_class_methods.py`
+12. **11 — dunder methods (`__repr__`, `__add__`, `__eq__`)**  
+    Exercise: `exercises/11_dunder_methods/vector2d.py`  
+    Solution: `solutions/11_dunder_methods.py`
+13. **12 — abstract methods and polymorphism (ABC)**  
+    Exercise: `exercises/12_abstract_methods/shape_pricing.py`  
+    Solution: `solutions/12_abstract_methods.py`
+14. **13 — mixins and `super()` method reuse**  
+    Exercise: `exercises/13_mixin_super_calls/notifications.py`  
+    Solution: `solutions/13_mixin_super_calls.py`

--- a/py03lings/README.md
+++ b/py03lings/README.md
@@ -1,6 +1,6 @@
 # py03lings
 
-A rustlings-style practice track for Python 3 fundamentals, including intro async exercises.
+A rustlings-style practice track for Python 3 fundamentals, async exercises, and object-oriented method drills.
 
 ## How to use
 

--- a/py03lings/exercises/10_instance_class_methods/bank_account.py
+++ b/py03lings/exercises/10_instance_class_methods/bank_account.py
@@ -1,0 +1,33 @@
+"""Exercise 10: practice instance methods and class methods."""
+
+
+class BankAccount:
+    bank_name = "Py03 Credit Union"
+
+    def __init__(self, owner: str, balance: float = 0.0) -> None:
+        self.owner = owner
+        self.balance = balance
+
+    def deposit(self, amount: float) -> float:
+        # TODO: raise ValueError if amount <= 0
+        # TODO: add amount to balance
+        # TODO: return updated balance
+        return self.balance
+
+    def withdraw(self, amount: float) -> float:
+        # TODO: raise ValueError if amount <= 0
+        # TODO: raise ValueError if amount > balance
+        # TODO: subtract amount and return updated balance
+        return self.balance
+
+    @classmethod
+    def starter_account(cls, owner: str) -> "BankAccount":
+        # TODO: return an account with a 25.0 starter bonus
+        return cls(owner, 0.0)
+
+
+if __name__ == "__main__":
+    account = BankAccount.starter_account("Avery")
+    account.deposit(10)
+    account.withdraw(5)
+    print(account.owner, account.balance, account.bank_name)

--- a/py03lings/exercises/11_dunder_methods/vector2d.py
+++ b/py03lings/exercises/11_dunder_methods/vector2d.py
@@ -1,0 +1,27 @@
+"""Exercise 11: implement advanced object methods (dunder methods)."""
+
+
+class Vector2D:
+    def __init__(self, x: float, y: float) -> None:
+        self.x = x
+        self.y = y
+
+    def __repr__(self) -> str:
+        # TODO: return exactly Vector2D(x=<x>, y=<y>)
+        return "Vector2D(x=0, y=0)"
+
+    def __add__(self, other: "Vector2D") -> "Vector2D":
+        # TODO: return a new vector that adds matching coordinates
+        return Vector2D(0, 0)
+
+    def __eq__(self, other: object) -> bool:
+        # TODO: return False when other is not Vector2D
+        # TODO: compare x and y values for equality
+        return False
+
+
+if __name__ == "__main__":
+    v1 = Vector2D(1, 2)
+    v2 = Vector2D(3, 4)
+    print(v1 + v2)
+    print(v1 == Vector2D(1, 2))

--- a/py03lings/exercises/12_abstract_methods/shape_pricing.py
+++ b/py03lings/exercises/12_abstract_methods/shape_pricing.py
@@ -1,0 +1,39 @@
+"""Exercise 12: use abstract methods for polymorphism."""
+
+from abc import ABC, abstractmethod
+
+
+class Shape(ABC):
+    @abstractmethod
+    def area(self) -> float:
+        """Return shape area."""
+
+
+class Rectangle(Shape):
+    def __init__(self, width: float, height: float) -> None:
+        self.width = width
+        self.height = height
+
+    def area(self) -> float:
+        # TODO: return rectangle area
+        return 0.0
+
+
+class Circle(Shape):
+    def __init__(self, radius: float) -> None:
+        self.radius = radius
+
+    def area(self) -> float:
+        # TODO: return circle area using 3.14159 for pi
+        return 0.0
+
+
+def total_paint_cost(shapes: list[Shape], price_per_unit: float) -> float:
+    # TODO: sum all areas
+    # TODO: multiply by price_per_unit
+    return 0.0
+
+
+if __name__ == "__main__":
+    shapes = [Rectangle(3, 4), Circle(1)]
+    print(total_paint_cost(shapes, 2.5))

--- a/py03lings/exercises/13_mixin_super_calls/notifications.py
+++ b/py03lings/exercises/13_mixin_super_calls/notifications.py
@@ -1,0 +1,28 @@
+"""Exercise 13: combine mixins with super() for reusable behavior."""
+
+
+class TimestampMixin:
+    def stamp(self) -> str:
+        # TODO: return a fixed timestamp string "[2026-01-01T00:00:00Z]"
+        return ""
+
+
+class Message:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+    def render(self) -> str:
+        return self.text
+
+
+class StampedMessage(TimestampMixin, Message):
+    def render(self) -> str:
+        # TODO: call self.stamp()
+        # TODO: call super().render()
+        # TODO: return "<stamp> <message>"
+        return ""
+
+
+if __name__ == "__main__":
+    msg = StampedMessage("Deployment succeeded")
+    print(msg.render())

--- a/py03lings/solutions/10_instance_class_methods.py
+++ b/py03lings/solutions/10_instance_class_methods.py
@@ -1,0 +1,34 @@
+"""Solution 10: practice instance methods and class methods."""
+
+
+class BankAccount:
+    bank_name = "Py03 Credit Union"
+
+    def __init__(self, owner: str, balance: float = 0.0) -> None:
+        self.owner = owner
+        self.balance = balance
+
+    def deposit(self, amount: float) -> float:
+        if amount <= 0:
+            raise ValueError("Deposit amount must be positive.")
+        self.balance += amount
+        return self.balance
+
+    def withdraw(self, amount: float) -> float:
+        if amount <= 0:
+            raise ValueError("Withdrawal amount must be positive.")
+        if amount > self.balance:
+            raise ValueError("Insufficient funds.")
+        self.balance -= amount
+        return self.balance
+
+    @classmethod
+    def starter_account(cls, owner: str) -> "BankAccount":
+        return cls(owner, 25.0)
+
+
+if __name__ == "__main__":
+    account = BankAccount.starter_account("Avery")
+    account.deposit(10)
+    account.withdraw(5)
+    print(account.owner, account.balance, account.bank_name)

--- a/py03lings/solutions/11_dunder_methods.py
+++ b/py03lings/solutions/11_dunder_methods.py
@@ -1,0 +1,25 @@
+"""Solution 11: implement advanced object methods (dunder methods)."""
+
+
+class Vector2D:
+    def __init__(self, x: float, y: float) -> None:
+        self.x = x
+        self.y = y
+
+    def __repr__(self) -> str:
+        return f"Vector2D(x={self.x}, y={self.y})"
+
+    def __add__(self, other: "Vector2D") -> "Vector2D":
+        return Vector2D(self.x + other.x, self.y + other.y)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Vector2D):
+            return False
+        return self.x == other.x and self.y == other.y
+
+
+if __name__ == "__main__":
+    v1 = Vector2D(1, 2)
+    v2 = Vector2D(3, 4)
+    print(v1 + v2)
+    print(v1 == Vector2D(1, 2))

--- a/py03lings/solutions/12_abstract_methods.py
+++ b/py03lings/solutions/12_abstract_methods.py
@@ -1,0 +1,35 @@
+"""Solution 12: use abstract methods for polymorphism."""
+
+from abc import ABC, abstractmethod
+
+
+class Shape(ABC):
+    @abstractmethod
+    def area(self) -> float:
+        """Return shape area."""
+
+
+class Rectangle(Shape):
+    def __init__(self, width: float, height: float) -> None:
+        self.width = width
+        self.height = height
+
+    def area(self) -> float:
+        return self.width * self.height
+
+
+class Circle(Shape):
+    def __init__(self, radius: float) -> None:
+        self.radius = radius
+
+    def area(self) -> float:
+        return 3.14159 * self.radius * self.radius
+
+
+def total_paint_cost(shapes: list[Shape], price_per_unit: float) -> float:
+    return sum(shape.area() for shape in shapes) * price_per_unit
+
+
+if __name__ == "__main__":
+    shapes = [Rectangle(3, 4), Circle(1)]
+    print(total_paint_cost(shapes, 2.5))

--- a/py03lings/solutions/13_mixin_super_calls.py
+++ b/py03lings/solutions/13_mixin_super_calls.py
@@ -1,0 +1,24 @@
+"""Solution 13: combine mixins with super() for reusable behavior."""
+
+
+class TimestampMixin:
+    def stamp(self) -> str:
+        return "[2026-01-01T00:00:00Z]"
+
+
+class Message:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+    def render(self) -> str:
+        return self.text
+
+
+class StampedMessage(TimestampMixin, Message):
+    def render(self) -> str:
+        return f"{self.stamp()} {super().render()}"
+
+
+if __name__ == "__main__":
+    msg = StampedMessage("Deployment succeeded")
+    print(msg.render())


### PR DESCRIPTION
### Motivation

- Provide a small, ordered progression of object-orientation exercises to teach instance/class methods through mixins and `super()` reuse.
- Surface these OOP drills in the track index so learners can find and work through basic→advanced method patterns.

### Description

- Rewrote `py03lings/EXERCISES.md` into numbered sections and added an "Object orientation methods (basic → advanced)" group (exercises 10–13). 
- Added four new exercise stubs with TODOs under `py03lings/exercises/10_instance_class_methods`, `11_dunder_methods`, `12_abstract_methods`, and `13_mixin_super_calls` to cover `BankAccount`, `Vector2D`, `Shape`/`Rectangle`/`Circle`, and `StampedMessage` respectively. 
- Added matching solution files in `py03lings/solutions/` for each new exercise implementing the expected behavior. 
- Updated `py03lings/README.md` to mention the new object-oriented method drills. 

### Testing

- Ran `python py03lings/check.py` which executed successfully and printed TODO counts (including the new exercise stubs). 
- Ran `python -m compileall py03lings/exercises py03lings/solutions` which completed successfully and compiled the new modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de57245044832e946b408b905db3f2)