### PR TITLE
Add PyG practice roadmap and exercises 79–84 scaffolds

### DIFF
--- a/pyg_exercise_roadmap.md
+++ b/pyg_exercise_roadmap.md
@@ -1,0 +1,126 @@
+# PyG Practice Roadmap (Beginner → Advanced)
+
+This roadmap turns your graph learning book into a practical, hands-on PyTorch Geometric ladder.  
+Each exercise has a **goal**, a **build target**, and a **one-line success criterion**.
+
+## Stage 1 — Graph Fundamentals and Classical Baselines
+
+### 1) Hand-build tiny `Data` objects
+- Build: one undirected, one directed, one weighted graph in PyG `Data`.
+- Include: `x`, `edge_index`, optional `edge_attr`, and boolean masks.
+- **Success criterion:** you can print and verify all tensor shapes and run one forward pass of a trivial MLP on node features.
+
+### 2) Build a typed mini graph with `HeteroData`
+- Build: two node types and at least two edge types.
+- Include: per-type features and typed connectivity.
+- **Success criterion:** `HeteroData` object is valid and each node/edge type reports expected counts.
+
+### 3) Convert adjacency ↔ edge list and test permutation invariance
+- Implement conversion from adjacency matrix to `edge_index` and back.
+- Permute node ordering and remap labels/features consistently.
+- **Success criterion:** task labels and graph-level properties are unchanged after node index permutation.
+
+### 4) Classical node statistics as features
+- Compute: degree, clustering coefficient, eigenvector centrality, and one ego-graph motif count.
+- Concatenate with original node features.
+- **Success criterion:** an MLP/logistic baseline with enriched features beats raw-feature baseline on validation accuracy.
+
+### 5) Overlap heuristics for link prediction
+- Implement: Common Neighbors, Jaccard, Adamic-Adar, Resource Allocation.
+- Evaluate on held-out positive/negative edges.
+- **Success criterion:** you report AUC/AP and at least one heuristic clearly outperforms random scoring.
+
+## Stage 2 — Spectral and Shallow Embeddings
+
+### 6) Laplacian spectral embedding + clustering
+- Build adjacency, degree, unnormalized + normalized Laplacian.
+- Extract first nontrivial eigenvectors and run k-means in 2D embedding space.
+- **Success criterion:** cluster assignments are meaningfully correlated with known node groups (or synthetic communities).
+
+### 7) Shallow encoder-decoder embedding (matrix reconstruction)
+- Learn node embeddings as trainable parameters.
+- Decode edges with dot product and train with negative sampling.
+- **Success criterion:** reconstruction loss drops steadily and link AUC exceeds heuristic baseline on same split.
+
+### 8) Random-walk / DeepWalk-style embeddings
+- Generate random walks and context windows.
+- Train skip-gram style embedding lookup model.
+- **Success criterion:** nearest-neighbor nodes in embedding space share labels/roles more often than chance.
+
+## Stage 3 — First Message-Passing Models
+
+### 9) First real GNN for node classification (`GCNConv` or `SAGEConv`)
+- Train with masked loss (`train_mask`, `val_mask`, `test_mask`).
+- Include self-loops + normalization handling.
+- **Success criterion:** validation performance improves over non-graph MLP baseline.
+
+### 10) Aggregator ablation: GCN vs SAGE vs GAT
+- Compare: GCN, GraphSAGE (mean), max/sum aggregation, and GAT.
+- Keep splits and optimization budget fixed.
+- **Success criterion:** produce a clean comparison table (accuracy/F1 + runtime) and identify one best tradeoff.
+
+### 11) Update-function ablation
+- Add and compare: plain update, concat skip, residual, GRU/gated update, and Jumping Knowledge.
+- Probe shallow vs deeper stacks.
+- **Success criterion:** you can show which update style delays depth degradation on your dataset.
+
+### 12) Oversmoothing and depth sensitivity study
+- Train 2/4/8/16-layer variants on same data.
+- Track embedding variance and class separation over depth.
+- **Success criterion:** you provide a plot/table showing where oversmoothing starts and which architecture resists it best.
+
+## Stage 4 — Graph-Level and Edge-Level Tasks
+
+### 13) Graph classification with pooling strategies
+- Compare global mean/add/max, attention pooling, and Set2Set-style pooling.
+- Use small-graph dataset (or synthetic graphs with labels).
+- **Success criterion:** pooled-graph model outperforms a simple handcrafted-feature baseline and you identify when each pooling type helps.
+
+### 14) GNN encoder + decoder for link prediction
+- Encode nodes with GCN/SAGE.
+- Decode with dot product and MLP-on-pairs.
+- Train with negative sampling; evaluate AUC/AP.
+- **Success criterion:** GNN-based link predictor beats overlap heuristics from Exercise 5 on same split protocol.
+
+### 15) Edge-feature and relation-aware prediction
+- Add edge attributes and/or typed edges in the predictor.
+- Compare plain vs edge-aware decoder.
+- **Success criterion:** edge-aware model improves AP or calibration for relation prediction.
+
+### 16) Heterogeneous / multi-relational GNN
+- Build `HeteroData` with multiple node/edge types.
+- Train RGCN-like or per-relation message passing model.
+- **Success criterion:** typed model outperforms type-agnostic collapse baseline.
+
+## Stage 5 — Theory, Scale, and Pretraining
+
+### 17) WL expressiveness playground (theory-meets-code)
+- Implement 1-WL color refinement.
+- Compare WL, GIN-style model, and weaker GCN on challenging graph pairs.
+- **Success criterion:** you produce at least one pair where GIN/WL distinguish and GCN fails (or vice versa with explanation).
+
+### 18) Efficiency: full-batch vs neighbor sampling vs subgraph mini-batching
+- Run same node task with three training regimes.
+- Track memory, throughput, and performance.
+- **Success criterion:** report a Pareto-style comparison showing compute/performance trade-offs.
+
+### 19) Self-supervised pretraining + fine-tuning
+- Pretext options: edge masking, feature masking, context prediction, or graph contrastive objective.
+- Fine-tune on node or graph classification.
+- **Success criterion:** pretrained initialization improves convergence speed and/or final metric over scratch.
+
+### 20) Generative graph model (VGAE or autoregressive)
+- Implement VGAE (recommended) or simple autoregressive edge addition.
+- Evaluate reconstruction + sampled graph quality statistics.
+- **Success criterion:** generated/reconstructed graphs match key structural statistics better than random baseline.
+
+---
+
+## Chemistry-focused fast track (recommended order)
+1. Exercises 1 → 2 → 4  
+2. Exercises 9 → 13 → 14  
+3. Exercises 15 → 16  
+4. Exercise 17  
+5. Exercise 20 (molecular-graph flavored)
+
+Use molecular descriptors and atom/bond features early so every stage stays relevant to polymer/material tasks.

--- a/pytorchlings/EXERCISES.md
+++ b/pytorchlings/EXERCISES.md
@@ -85,4 +85,9 @@
 | 76 | PyTorch | Molecular graph message passing (from scratch) | `exercises/76_molecular_graph_message_passing/molecular_graph_message_passing.py` | `N/A (exercise scaffold)` |
 | 77 | PyTorch | SMILES LSTM property prediction scaffold | `exercises/77_smiles_lstm_property/smiles_lstm_property.py` | `N/A (exercise scaffold)` |
 | 78 | PyTorch | Protein-ligand 3D CNN scoring scaffold | `exercises/78_protein_ligand_3dcnn/protein_ligand_3dcnn.py` | `N/A (exercise scaffold)` |
-
+| 79 | PyG + NetworkX | Overlap heuristics for link prediction baselines | `exercises/79_overlap_link_heuristics/overlap_link_heuristics.py` | `N/A (exercise scaffold)` |
+| 80 | PyG + Spectral | Laplacian embeddings + spectral clustering | `exercises/80_laplacian_spectral_clustering/laplacian_spectral_clustering.py` | `N/A (exercise scaffold)` |
+| 81 | Theory + PyG | Weisfeiler-Lehman expressiveness lab | `exercises/81_wl_expressiveness_lab/wl_expressiveness_lab.py` | `N/A (exercise scaffold)` |
+| 82 | PyG | Neighbor sampling and efficiency comparison | `exercises/82_neighbor_sampling_efficiency/neighbor_sampling_efficiency.py` | `N/A (exercise scaffold)` |
+| 83 | PyG + SSL | Self-supervised graph pretraining scaffold | `exercises/83_self_supervised_graph_pretraining/self_supervised_graph_pretraining.py` | `N/A (exercise scaffold)` |
+| 84 | PyG | Variational graph autoencoder (VGAE) scaffold | `exercises/84_vgae_molecular_generation/vgae_molecular_generation.py` | `N/A (exercise scaffold)` |

--- a/pytorchlings/README.md
+++ b/pytorchlings/README.md
@@ -25,6 +25,7 @@ A rustlings-style practice track for **PyTorch** and **PyTorch Geometric (PyG)**
 - Add 62-65 for chemistry-oriented generative modeling, hill-climbing evals, and slice-based scientific error analysis.
 - Add 66-73 for interview-focused research practice: math refresh drills, from-scratch baselines, accelerator-native patterns, RDKit/PyG pipelines, graph-vs-geometry modeling, reproducible training stacks, and ablation reporting.
 - Add 74-78 for chemistry-model progression examples: fingerprint MLP baseline, multitask masking, molecular message passing, SMILES LSTM, and protein-ligand 3D CNN.
+- Add 79-84 for graph-learning roadmap extensions: overlap link heuristics, spectral clustering, WL expressiveness, sampling efficiency, self-supervised pretraining, and VGAE generation.
 
 ## Quick check command
 
@@ -101,3 +102,14 @@ Exercises 74-78 provide direct hands-on scaffolds matching a practical chemistry
 - Molecular graph message passing and graph-level readout
 - SMILES LSTM sequence modeling
 - 3D CNN scoring on voxelized protein-ligand neighborhoods
+
+## Graph learning roadmap extension
+
+Exercises 79-84 expand the PyG ladder with the next set of high-value practice tasks:
+
+- Classical overlap baselines for link prediction (Common Neighbors/Jaccard/Adamic-Adar/RA)
+- Laplacian construction and spectral clustering intuition
+- 1-WL color refinement and expressiveness limits
+- Full-batch versus sampled mini-batch efficiency comparisons
+- Self-supervised graph pretraining before fine-tuning
+- Variational graph autoencoder scaffolding for graph generation

--- a/pytorchlings/exercises/79_overlap_link_heuristics/overlap_link_heuristics.py
+++ b/pytorchlings/exercises/79_overlap_link_heuristics/overlap_link_heuristics.py
@@ -1,0 +1,80 @@
+"""Exercise 79: overlap heuristics for link prediction.
+
+Goal:
+- implement classical edge scores before any GNN
+- compare heuristic ranking quality with AUC/AP
+- build a reliable baseline for relation prediction
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections import defaultdict
+
+
+def make_toy_edges() -> list[tuple[int, int]]:
+    """Undirected toy graph edge list."""
+    return [
+        (0, 1),
+        (0, 2),
+        (1, 2),
+        (1, 3),
+        (2, 4),
+        (3, 4),
+        (4, 5),
+    ]
+
+
+def build_neighbors(edges: list[tuple[int, int]]) -> dict[int, set[int]]:
+    nbrs: dict[int, set[int]] = defaultdict(set)
+    for u, v in edges:
+        nbrs[u].add(v)
+        nbrs[v].add(u)
+    return dict(nbrs)
+
+
+def common_neighbors(nbrs: dict[int, set[int]], u: int, v: int) -> int:
+    return len(nbrs.get(u, set()) & nbrs.get(v, set()))
+
+
+def jaccard(nbrs: dict[int, set[int]], u: int, v: int) -> float:
+    a, b = nbrs.get(u, set()), nbrs.get(v, set())
+    den = len(a | b)
+    return 0.0 if den == 0 else len(a & b) / den
+
+
+def adamic_adar(nbrs: dict[int, set[int]], u: int, v: int) -> float:
+    """TODO: implement Adamic-Adar index with log-degree denominator."""
+    _ = (nbrs, u, v)
+    return 0.0
+
+
+def resource_allocation(nbrs: dict[int, set[int]], u: int, v: int) -> float:
+    """TODO: implement Resource Allocation index."""
+    _ = (nbrs, u, v)
+    return 0.0
+
+
+def non_edges(nodes: list[int], edges: set[tuple[int, int]]) -> list[tuple[int, int]]:
+    cands = []
+    for u, v in itertools.combinations(nodes, 2):
+        e = (u, v) if u < v else (v, u)
+        if e not in edges:
+            cands.append(e)
+    return cands
+
+
+if __name__ == "__main__":
+    edges = make_toy_edges()
+    edge_set = {(u, v) if u < v else (v, u) for (u, v) in edges}
+    nodes = sorted(set([n for e in edges for n in e]))
+
+    nbrs = build_neighbors(edges)
+    negatives = non_edges(nodes, edge_set)
+
+    assert common_neighbors(nbrs, 0, 3) >= 1
+    assert 0.0 <= jaccard(nbrs, 0, 3) <= 1.0
+    assert len(negatives) > 0
+
+    # TODO: add held-out split + AUC/AP evaluation across all heuristic scores.
+    print("exercise 79 scaffold ready")

--- a/pytorchlings/exercises/80_laplacian_spectral_clustering/laplacian_spectral_clustering.py
+++ b/pytorchlings/exercises/80_laplacian_spectral_clustering/laplacian_spectral_clustering.py
@@ -1,0 +1,56 @@
+"""Exercise 80: Laplacian embedding + spectral clustering.
+
+Goal:
+- build graph Laplacians from adjacency
+- extract non-trivial eigenvectors as node embeddings
+- cluster embeddings and compare to known communities
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def ring_with_chord_adjacency(n: int = 8) -> torch.Tensor:
+    a = torch.zeros((n, n), dtype=torch.float32)
+    for i in range(n):
+        a[i, (i + 1) % n] = 1.0
+        a[(i + 1) % n, i] = 1.0
+    a[0, 4] = 1.0
+    a[4, 0] = 1.0
+    return a
+
+
+def laplacian_unnormalized(a: torch.Tensor) -> torch.Tensor:
+    d = torch.diag(a.sum(dim=1))
+    return d - a
+
+
+def laplacian_normalized(a: torch.Tensor) -> torch.Tensor:
+    d = a.sum(dim=1)
+    d_inv_sqrt = torch.where(d > 0, d.rsqrt(), torch.zeros_like(d))
+    d_inv_sqrt_mat = torch.diag(d_inv_sqrt)
+    i = torch.eye(a.size(0), dtype=a.dtype)
+    return i - d_inv_sqrt_mat @ a @ d_inv_sqrt_mat
+
+
+def top_nontrivial_evecs(l: torch.Tensor, k: int = 2) -> torch.Tensor:
+    vals, vecs = torch.linalg.eigh(l)
+    idx = torch.argsort(vals)
+    # skip first eigenvector (trivial component)
+    keep = idx[1 : 1 + k]
+    return vecs[:, keep]
+
+
+if __name__ == "__main__":
+    a = ring_with_chord_adjacency(8)
+    l = laplacian_unnormalized(a)
+    l_norm = laplacian_normalized(a)
+    emb = top_nontrivial_evecs(l_norm, k=2)
+
+    assert a.shape == (8, 8)
+    assert l.shape == (8, 8) and l_norm.shape == (8, 8)
+    assert emb.shape == (8, 2)
+
+    # TODO: add k-means over `emb` and report cluster purity/NMI against labels.
+    print("exercise 80 scaffold ready")

--- a/pytorchlings/exercises/81_wl_expressiveness_lab/wl_expressiveness_lab.py
+++ b/pytorchlings/exercises/81_wl_expressiveness_lab/wl_expressiveness_lab.py
@@ -1,0 +1,56 @@
+"""Exercise 81: Weisfeiler-Lehman expressiveness lab.
+
+Goal:
+- implement 1-WL color refinement
+- build graph pairs that challenge weak aggregators
+- compare WL outcomes to GCN/GIN behavior
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+
+def wl_refine(adj_list: dict[int, list[int]], num_steps: int = 3) -> dict[int, int]:
+    """Simple 1-WL color refinement with integer color hashing."""
+    colors = {n: 1 for n in adj_list}
+    for _ in range(num_steps):
+        signatures = {}
+        for n in adj_list:
+            neighborhood = tuple(sorted(colors[m] for m in adj_list[n]))
+            signatures[n] = (colors[n], neighborhood)
+        uniq = {sig: i + 1 for i, sig in enumerate(sorted(set(signatures.values())))}
+        colors = {n: uniq[sig] for n, sig in signatures.items()}
+    return colors
+
+
+def cycle_graph(n: int) -> dict[int, list[int]]:
+    return {i: [(i - 1) % n, (i + 1) % n] for i in range(n)}
+
+
+def two_triangles() -> dict[int, list[int]]:
+    return {
+        0: [1, 2],
+        1: [0, 2],
+        2: [0, 1],
+        3: [4, 5],
+        4: [3, 5],
+        5: [3, 4],
+    }
+
+
+if __name__ == "__main__":
+    g1 = cycle_graph(6)
+    g2 = two_triangles()
+
+    c1 = wl_refine(g1, num_steps=3)
+    c2 = wl_refine(g2, num_steps=3)
+
+    hist1 = Counter(c1.values())
+    hist2 = Counter(c2.values())
+
+    assert len(c1) == 6 and len(c2) == 6
+    assert sum(hist1.values()) == 6 and sum(hist2.values()) == 6
+
+    # TODO: add additional graph pairs and compare with a small GIN + GCN experiment.
+    print("exercise 81 scaffold ready", hist1, hist2)

--- a/pytorchlings/exercises/82_neighbor_sampling_efficiency/neighbor_sampling_efficiency.py
+++ b/pytorchlings/exercises/82_neighbor_sampling_efficiency/neighbor_sampling_efficiency.py
@@ -1,0 +1,60 @@
+"""Exercise 82: efficiency with full-batch vs neighbor sampling.
+
+Goal:
+- compare memory/time tradeoffs in large-graph training
+- run identical model under different batching regimes
+- quantify the accuracy-vs-throughput frontier
+"""
+
+from __future__ import annotations
+
+import time
+
+import torch
+from torch_geometric.data import Data
+
+
+class TinyEncoder(torch.nn.Module):
+    def __init__(self, in_dim: int, hidden: int, out_dim: int):
+        super().__init__()
+        self.net = torch.nn.Sequential(
+            torch.nn.Linear(in_dim, hidden),
+            torch.nn.ReLU(),
+            torch.nn.Linear(hidden, out_dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+def make_denseish_graph(n: int = 3000, d: int = 32) -> Data:
+    torch.manual_seed(82)
+    x = torch.randn(n, d)
+    src = torch.randint(0, n, (n * 8,))
+    dst = torch.randint(0, n, (n * 8,))
+    edge_index = torch.stack([src, dst], dim=0)
+    y = torch.randint(0, 3, (n,))
+    train_mask = torch.zeros(n, dtype=torch.bool)
+    train_mask[: int(0.7 * n)] = True
+    return Data(x=x, edge_index=edge_index, y=y, train_mask=train_mask)
+
+
+def run_full_batch_stub(data: Data) -> float:
+    model = TinyEncoder(data.x.size(1), 64, 3)
+    start = time.perf_counter()
+    _ = model(data.x)
+    return time.perf_counter() - start
+
+
+def run_neighbor_sampling_stub(data: Data) -> float:
+    """TODO: replace with NeighborLoader-based mini-batch training runtime."""
+    return run_full_batch_stub(data)
+
+
+if __name__ == "__main__":
+    data = make_denseish_graph()
+    t_full = run_full_batch_stub(data)
+    t_sample = run_neighbor_sampling_stub(data)
+
+    assert t_full >= 0.0 and t_sample >= 0.0
+    print(f"exercise 82 scaffold ready | full={t_full:.6f}s sampled={t_sample:.6f}s")

--- a/pytorchlings/exercises/83_self_supervised_graph_pretraining/self_supervised_graph_pretraining.py
+++ b/pytorchlings/exercises/83_self_supervised_graph_pretraining/self_supervised_graph_pretraining.py
@@ -1,0 +1,63 @@
+"""Exercise 83: self-supervised graph pretraining + fine-tune.
+
+Goal:
+- pretrain a node encoder with masked feature reconstruction
+- transfer encoder to downstream node classification
+- compare scratch vs pretrained initialization
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch_geometric.data import Data
+
+
+class MLPEncoder(nn.Module):
+    def __init__(self, in_dim: int, hidden: int):
+        super().__init__()
+        self.net = nn.Sequential(nn.Linear(in_dim, hidden), nn.ReLU(), nn.Linear(hidden, hidden))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+class MaskedFeatureHead(nn.Module):
+    def __init__(self, hidden: int, out_dim: int):
+        super().__init__()
+        self.proj = nn.Linear(hidden, out_dim)
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        return self.proj(z)
+
+
+def make_graph(n: int = 256, d: int = 24) -> Data:
+    torch.manual_seed(83)
+    x = torch.randn(n, d)
+    src = torch.randint(0, n, (n * 4,))
+    dst = torch.randint(0, n, (n * 4,))
+    y = torch.randint(0, 4, (n,))
+    return Data(x=x, edge_index=torch.stack([src, dst], dim=0), y=y)
+
+
+def random_mask(x: torch.Tensor, p: float = 0.3) -> tuple[torch.Tensor, torch.Tensor]:
+    mask = torch.rand_like(x).lt(p)
+    x_masked = x.clone()
+    x_masked[mask] = 0.0
+    return x_masked, mask
+
+
+if __name__ == "__main__":
+    data = make_graph()
+    encoder = MLPEncoder(in_dim=data.x.size(1), hidden=32)
+    head = MaskedFeatureHead(hidden=32, out_dim=data.x.size(1))
+
+    x_masked, mask = random_mask(data.x)
+    z = encoder(x_masked)
+    x_hat = head(z)
+
+    assert x_hat.shape == data.x.shape
+    assert mask.dtype == torch.bool
+
+    # TODO: implement pretrain loop, then downstream fine-tune comparison against scratch.
+    print("exercise 83 scaffold ready")

--- a/pytorchlings/exercises/84_vgae_molecular_generation/vgae_molecular_generation.py
+++ b/pytorchlings/exercises/84_vgae_molecular_generation/vgae_molecular_generation.py
@@ -1,0 +1,58 @@
+"""Exercise 84: VGAE scaffold for molecular-style graph generation.
+
+Goal:
+- implement variational graph autoencoder encode/decode path
+- train with reconstruction + KL terms
+- sample latent vectors and decode candidate graph edges
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+from torch_geometric.data import Data
+
+
+class TinyVGAEEncoder(nn.Module):
+    def __init__(self, in_dim: int, hidden: int, latent: int):
+        super().__init__()
+        self.backbone = nn.Sequential(nn.Linear(in_dim, hidden), nn.ReLU())
+        self.mu_head = nn.Linear(hidden, latent)
+        self.logvar_head = nn.Linear(hidden, latent)
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        h = self.backbone(x)
+        return self.mu_head(h), self.logvar_head(h)
+
+
+def reparameterize(mu: torch.Tensor, logvar: torch.Tensor) -> torch.Tensor:
+    std = torch.exp(0.5 * logvar)
+    eps = torch.randn_like(std)
+    return mu + eps * std
+
+
+def decode_inner_product(z: torch.Tensor) -> torch.Tensor:
+    return z @ z.T
+
+
+def make_toy_molecule_graph(n: int = 20, d: int = 12) -> Data:
+    torch.manual_seed(84)
+    x = torch.randn(n, d)
+    src = torch.randint(0, n, (n * 3,))
+    dst = torch.randint(0, n, (n * 3,))
+    edge_index = torch.stack([src, dst], dim=0)
+    return Data(x=x, edge_index=edge_index)
+
+
+if __name__ == "__main__":
+    data = make_toy_molecule_graph()
+    enc = TinyVGAEEncoder(in_dim=data.x.size(1), hidden=32, latent=16)
+    mu, logvar = enc(data.x)
+    z = reparameterize(mu, logvar)
+    logits = decode_inner_product(z)
+
+    assert mu.shape == logvar.shape == (data.num_nodes, 16)
+    assert logits.shape == (data.num_nodes, data.num_nodes)
+
+    # TODO: add BCE reconstruction on positive/negative edges + KL divergence training loop.
+    print("exercise 84 scaffold ready")


### PR DESCRIPTION
### Motivation
- Expand the PyG learning ladder with a focused roadmap and the next set of hands-on scaffolds for classical baselines, spectral methods, WL theory, sampling efficiency, self-supervision, and VGAE generation.
- Provide small, runnable scaffolds that encode the exercise goals and basic smoke-checks so learners can iterate from a clear starting point.

### Description
- Add `pyg_exercise_roadmap.md` containing a staged PyG practice roadmap from fundamentals to pretraining/generative tasks.
- Update `pytorchlings/EXERCISES.md` and `pytorchlings/README.md` to register and document exercises `79`–`84` and mention the roadmap extension.
- Add new exercise scaffolds under `pytorchlings/exercises/` for: `79_overlap_link_heuristics`, `80_laplacian_spectral_clustering`, `81_wl_expressiveness_lab`, `82_neighbor_sampling_efficiency`, `83_self_supervised_graph_pretraining`, and `84_vgae_molecular_generation`, each implementing minimal utilities, example data builders, and `if __name__ == "__main__"` smoke assertions.
- Leave clear `TODO` markers in each scaffold for follow-up work (evaluation loops, training, and benchmarking) so they serve as exercise templates.

### Testing
- Performed smoke runs by executing each new exercise script (79–84) and confirmed their in-script assertions and shape checks passed. 
- Verified that each scaffold prints its ready message when run, indicating the basic checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de64887560832e8967042c55233833)