### PR TITLE
Add pytorchlings exercises 87-88: Lightning callbacks and scaled attention

### DIFF
--- a/pytorchlings/EXERCISES.md
+++ b/pytorchlings/EXERCISES.md
@@ -101,3 +101,5 @@
 | 84 | PyTorch | CNN-Transformer hybrid encoder | `exercises/84_cnn_transformer_hybrid/cnn_transformer_hybrid.py` | `solutions/84_cnn_transformer_hybrid.py` |
 | 85 | PyTorch | Graph-sequence co-encoder with bidirectional cross-attention | `exercises/85_graph_sequence_coencoder/graph_sequence_coencoder.py` | `solutions/85_graph_sequence_coencoder.py` |
 | 86 | PyTorch | Mixture-of-Experts multimodal router | `exercises/86_moe_multimodal_router/moe_multimodal_router.py` | `solutions/86_moe_multimodal_router.py` |
+| 87 | Lightning | Callback stack (EarlyStopping, checkpointing, LR monitor) | `exercises/87_lightning_callbacks/callbacks_and_early_stopping.py` | `solutions/87_callbacks_and_early_stopping.py` |
+| 88 | PyTorch | Scaled dot-product attention from scratch + causal masking | `exercises/88_attention_mechanics/scaled_dot_product_attention.py` | `solutions/88_scaled_dot_product_attention.py` |

--- a/pytorchlings/README.md
+++ b/pytorchlings/README.md
@@ -28,6 +28,7 @@ A rustlings-style practice track for **PyTorch** and **PyTorch Geometric (PyG)**
 - Add 79-84 for graph-learning roadmap extensions: overlap link heuristics, spectral clustering, WL expressiveness, sampling efficiency, self-supervised pretraining, and VGAE generation.
 - Continue 79-82 to reuse earlier building blocks in progressively more complex architectures: hybrid fusion, residual MPNNs, cross-attention fusion, and multimodal uncertainty modeling.
 - Extend 83-86 for deeper architectural composition in the pytorchlings folder: residual MLP backbones, CNN-transformer hybrids, graph-sequence co-encoders, and multimodal MoE routing.
+- Extend 87-88 for practical Lightning callback orchestration and first-principles attention mechanics.
 
 ## Quick check command
 
@@ -134,3 +135,11 @@ Exercises 83-86 continue the same cumulative pattern and explicitly push learner
 - 84: CNN feature extraction fused with transformer token mixing
 - 85: graph-sequence co-encoding with bidirectional cross-attention
 - 86: multimodal Mixture-of-Experts routing for specialization
+
+## Additional numerical exercises extension
+
+Exercises 87-88 add focused numerical drills requested for Lightning and attention understanding:
+
+- 87: configure a production-relevant Lightning callback stack (EarlyStopping, checkpointing, LR monitoring)
+- 88: implement scaled dot-product attention and causal masking from scratch to build attention intuition
+

--- a/pytorchlings/exercises/87_lightning_callbacks/callbacks_and_early_stopping.py
+++ b/pytorchlings/exercises/87_lightning_callbacks/callbacks_and_early_stopping.py
@@ -1,0 +1,24 @@
+"""Exercise 87: practical Lightning callbacks for stable training.
+
+Goal:
+- Configure EarlyStopping + ModelCheckpoint around `val_loss`
+- Attach LearningRateMonitor for optimizer diagnostics
+- Build a deterministic Trainer for reproducible debugging
+"""
+import lightning as L
+from lightning.pytorch.callbacks import EarlyStopping, LearningRateMonitor, ModelCheckpoint
+
+
+def build_callbacks() -> list:
+    # TODO: create EarlyStopping monitoring "val_loss" with mode="min" and patience=3
+    # TODO: create ModelCheckpoint monitoring "val_loss" with mode="min" and save_top_k=1
+    # TODO: create LearningRateMonitor with logging_interval="epoch"
+    # TODO: return callbacks list in the order [early_stop, checkpoint, lr_monitor]
+    raise NotImplementedError
+
+
+def build_trainer(max_epochs: int = 10) -> L.Trainer:
+    callbacks = build_callbacks()
+    # TODO: return a Trainer that is deterministic, uses callbacks above,
+    # TODO: disables progress bar, and disables default logger
+    raise NotImplementedError

--- a/pytorchlings/exercises/88_attention_mechanics/scaled_dot_product_attention.py
+++ b/pytorchlings/exercises/88_attention_mechanics/scaled_dot_product_attention.py
@@ -1,0 +1,36 @@
+"""Exercise 88: understand scaled dot-product attention from first principles."""
+import math
+
+import torch
+
+
+def scaled_dot_product_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    mask: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Compute attention output and attention probabilities.
+
+    Expected shapes:
+      q: (batch, heads, q_len, d_k)
+      k: (batch, heads, k_len, d_k)
+      v: (batch, heads, k_len, d_v)
+      mask: optional broadcastable mask where 0 means "blocked"
+
+    Returns:
+      output: (batch, heads, q_len, d_v)
+      probs: (batch, heads, q_len, k_len)
+    """
+    # TODO: compute raw attention scores q @ k^T
+    # TODO: scale by sqrt(d_k)
+    # TODO: if mask is provided, fill masked positions with a large negative value
+    # TODO: apply softmax over the key dimension
+    # TODO: multiply probabilities by v to get output
+    raise NotImplementedError
+
+
+def causal_mask(seq_len: int, device: torch.device | None = None) -> torch.Tensor:
+    """Return a lower-triangular causal mask of shape (1, 1, seq_len, seq_len)."""
+    # TODO: build lower triangular mask with ones on/under diagonal
+    raise NotImplementedError

--- a/pytorchlings/solutions/87_callbacks_and_early_stopping.py
+++ b/pytorchlings/solutions/87_callbacks_and_early_stopping.py
@@ -1,0 +1,21 @@
+"""Solution 87: practical Lightning callbacks for stable training."""
+import lightning as L
+from lightning.pytorch.callbacks import EarlyStopping, LearningRateMonitor, ModelCheckpoint
+
+
+def build_callbacks() -> list:
+    early_stop = EarlyStopping(monitor="val_loss", mode="min", patience=3)
+    checkpoint = ModelCheckpoint(monitor="val_loss", mode="min", save_top_k=1)
+    lr_monitor = LearningRateMonitor(logging_interval="epoch")
+    return [early_stop, checkpoint, lr_monitor]
+
+
+def build_trainer(max_epochs: int = 10) -> L.Trainer:
+    callbacks = build_callbacks()
+    return L.Trainer(
+        max_epochs=max_epochs,
+        deterministic=True,
+        callbacks=callbacks,
+        enable_progress_bar=False,
+        logger=False,
+    )

--- a/pytorchlings/solutions/88_scaled_dot_product_attention.py
+++ b/pytorchlings/solutions/88_scaled_dot_product_attention.py
@@ -1,0 +1,27 @@
+"""Solution 88: scaled dot-product attention from first principles."""
+import math
+
+import torch
+
+
+def scaled_dot_product_attention(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    mask: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    scores = torch.matmul(q, k.transpose(-2, -1))
+    d_k = q.size(-1)
+    scores = scores / math.sqrt(d_k)
+
+    if mask is not None:
+        scores = scores.masked_fill(mask == 0, -1e9)
+
+    probs = torch.softmax(scores, dim=-1)
+    output = torch.matmul(probs, v)
+    return output, probs
+
+
+def causal_mask(seq_len: int, device: torch.device | None = None) -> torch.Tensor:
+    lower = torch.tril(torch.ones(seq_len, seq_len, device=device))
+    return lower.view(1, 1, seq_len, seq_len)


### PR DESCRIPTION
### Motivation
- Provide additional numbered numerical drills focused on PyTorch Lightning callback orchestration and attention mechanics to strengthen hands-on understanding.
- Keep the track consistent with rustlings-style exercises by providing TODO scaffolds and matching solutions for self-guided practice.

### Description
- Add new exercise scaffolds `pytorchlings/exercises/87_lightning_callbacks/callbacks_and_early_stopping.py` and `pytorchlings/exercises/88_attention_mechanics/scaled_dot_product_attention.py` containing TODOs for learners.
- Add corresponding solution files `pytorchlings/solutions/87_callbacks_and_early_stopping.py` and `pytorchlings/solutions/88_scaled_dot_product_attention.py` implementing EarlyStopping/ModelCheckpoint/LR monitor and scaled dot-product attention + causal mask respectively.
- Update `pytorchlings/EXERCISES.md` and `pytorchlings/README.md` to list and describe exercises 87 and 88 so they appear in the exercise index and suggested flow.
- Commit the new files and documentation to the repository (commit message: "Add pytorchlings numerical exercises for Lightning callbacks and attention").

### Testing
- Ran `python -m compileall pytorchlings/exercises/87_lightning_callbacks pytorchlings/exercises/88_attention_mechanics pytorchlings/solutions/87_callbacks_and_early_stopping.py pytorchlings/solutions/88_scaled_dot_product_attention.py` and compilation completed successfully. 
- Performed a repository status check and created the commit for the changes, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0fa059930832eadb8b52a08712122)