### PR TITLE
Add algolings rustlings-style algorithm exercise track

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.txt
+++ b/README.txt
@@ -16,6 +16,7 @@ This repository is now a **multi-language learning workspace** rather than a sin
 - `src/data/` — data files used by scripts
 - `cxx/` — legacy C++ geometry code
 - `jaxlings/` — rustlings-style JAX exercises and solutions
+- `algolings/` — rustlings-style algorithms exercises from simple to complex
 
 ## Build / run notes
 

--- a/algolings/EXERCISES.md
+++ b/algolings/EXERCISES.md
@@ -1,0 +1,16 @@
+# Exercise List (with solution mapping)
+
+| # | Topic | Exercise File | Solution File |
+|---|---|---|---|
+| 00 | Linear search in an unsorted list. | `exercises/00_linear_search/find_first.py` | `solutions/00_find_first.py` |
+| 01 | Binary search in sorted input. | `exercises/01_binary_search/binary_search.py` | `solutions/01_binary_search.py` |
+| 02 | Two Sum with hash map in O(n). | `exercises/02_two_sum_hash/two_sum.py` | `solutions/02_two_sum.py` |
+| 03 | Prefix sums for range queries. | `exercises/03_prefix_sums/range_sum.py` | `solutions/03_range_sum.py` |
+| 04 | Sliding-window max sum of size k. | `exercises/04_sliding_window_max_sum/max_window_sum.py` | `solutions/04_max_window_sum.py` |
+| 05 | Valid parentheses using a stack. | `exercises/05_stack_balanced_parentheses/is_balanced.py` | `solutions/05_is_balanced.py` |
+| 06 | Shortest path in grid using BFS. | `exercises/06_queue_bfs_grid/shortest_path_grid.py` | `solutions/06_shortest_path_grid.py` |
+| 07 | Merge overlapping intervals. | `exercises/07_merge_intervals/merge_intervals.py` | `solutions/07_merge_intervals.py` |
+| 08 | Topological sort (Kahn's algorithm). | `exercises/08_topological_sort/toposort.py` | `solutions/08_toposort.py` |
+| 09 | Union-Find for connectivity queries. | `exercises/09_union_find_intro/union_find.py` | `solutions/09_union_find.py` |
+| 10 | Dijkstra shortest path with heap. | `exercises/10_dijkstra_shortest_path/dijkstra.py` | `solutions/10_dijkstra.py` |
+| 11 | Longest Increasing Subsequence (DP + binary search). | `exercises/11_dynamic_programming_lis/lis.py` | `solutions/11_lis.py` |

--- a/algolings/README.md
+++ b/algolings/README.md
@@ -1,0 +1,24 @@
+# algolings
+
+A rustlings-style practice track for **core algorithms**, ordered from simple to complex.
+
+## How to use
+
+1. Open an exercise in `algolings/exercises/...`.
+2. Fill every `TODO` section.
+3. Run the file with Python.
+4. Compare with the matching answer in `algolings/solutions/...`.
+
+## Progression path
+
+- 00-03: foundational searching, hashing, and prefix sums.
+- 04-07: windowing, stacks, queues/BFS, and interval merging.
+- 08-09: graph ordering and disjoint-set unions.
+- 10-11: weighted shortest paths and dynamic programming.
+
+## Quick check commands
+
+```bash
+python algolings/check.py
+python -m compileall algolings/exercises algolings/solutions
+```

--- a/algolings/check.py
+++ b/algolings/check.py
@@ -1,0 +1,15 @@
+"""Tiny rustlings-like helper: list exercises and count TODOs."""
+from pathlib import Path
+
+
+def main() -> None:
+    root = Path(__file__).parent / "exercises"
+    files = sorted(root.glob("**/*.py"))
+    for file in files:
+        todo_count = file.read_text().count("TODO")
+        status = "✅" if todo_count == 0 else f"🧩 {todo_count} TODOs"
+        print(f"{file.relative_to(root)} -> {status}")
+
+
+if __name__ == "__main__":
+    main()

--- a/algolings/exercises/00_linear_search/find_first.py
+++ b/algolings/exercises/00_linear_search/find_first.py
@@ -1,0 +1,17 @@
+"""Exercise 00: linear search.
+
+TODO:
+- Implement find_first so it returns the index of target in nums.
+- Return -1 when target is not present.
+"""
+
+
+def find_first(nums: list[int], target: int) -> int:
+    # TODO: write linear scan
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    assert find_first([4, 2, 7, 2], 7) == 2
+    assert find_first([4, 2, 7, 2], 5) == -1
+    print("ok")

--- a/algolings/exercises/01_binary_search/binary_search.py
+++ b/algolings/exercises/01_binary_search/binary_search.py
@@ -1,0 +1,17 @@
+"""Exercise 01: binary search on a sorted list.
+
+TODO:
+- Implement iterative binary search.
+- Return index of target or -1 if absent.
+"""
+
+
+def binary_search(nums: list[int], target: int) -> int:
+    # TODO: use left/right pointers
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    assert binary_search([1, 3, 5, 8, 13], 8) == 3
+    assert binary_search([1, 3, 5, 8, 13], 2) == -1
+    print("ok")

--- a/algolings/exercises/02_two_sum_hash/two_sum.py
+++ b/algolings/exercises/02_two_sum_hash/two_sum.py
@@ -1,0 +1,17 @@
+"""Exercise 02: two-sum with hashing.
+
+TODO:
+- Return indices (i, j) where nums[i] + nums[j] == target.
+- Return (-1, -1) if no pair exists.
+"""
+
+
+def two_sum(nums: list[int], target: int) -> tuple[int, int]:
+    # TODO: use hash map for O(n)
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    assert two_sum([2, 7, 11, 15], 9) == (0, 1)
+    assert two_sum([1, 2, 3], 10) == (-1, -1)
+    print("ok")

--- a/algolings/exercises/03_prefix_sums/range_sum.py
+++ b/algolings/exercises/03_prefix_sums/range_sum.py
@@ -1,0 +1,23 @@
+"""Exercise 03: prefix sums.
+
+TODO:
+- Build a prefix-sum array.
+- Implement range_sum(prefix, left, right) as inclusive range sum.
+"""
+
+
+def build_prefix(nums: list[int]) -> list[int]:
+    # TODO
+    raise NotImplementedError
+
+
+def range_sum(prefix: list[int], left: int, right: int) -> int:
+    # TODO
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    p = build_prefix([3, 1, 4, 1, 5])
+    assert range_sum(p, 1, 3) == 6
+    assert range_sum(p, 0, 4) == 14
+    print("ok")

--- a/algolings/exercises/04_sliding_window_max_sum/max_window_sum.py
+++ b/algolings/exercises/04_sliding_window_max_sum/max_window_sum.py
@@ -1,0 +1,17 @@
+"""Exercise 04: fixed-size sliding window.
+
+TODO:
+- Return maximum sum of any contiguous subarray of length k.
+- Return 0 when k is invalid.
+"""
+
+
+def max_window_sum(nums: list[int], k: int) -> int:
+    # TODO
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    assert max_window_sum([1, 2, 3, 4, 5], 2) == 9
+    assert max_window_sum([5, -2, 3, 1], 3) == 6
+    print("ok")

--- a/algolings/exercises/05_stack_balanced_parentheses/is_balanced.py
+++ b/algolings/exercises/05_stack_balanced_parentheses/is_balanced.py
@@ -1,0 +1,17 @@
+"""Exercise 05: stack-based delimiter checking.
+
+TODO:
+- Return True when (), [], {} are balanced.
+- Return False otherwise.
+"""
+
+
+def is_balanced(text: str) -> bool:
+    # TODO
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    assert is_balanced("{[()]}") is True
+    assert is_balanced("([)]") is False
+    print("ok")

--- a/algolings/exercises/06_queue_bfs_grid/shortest_path_grid.py
+++ b/algolings/exercises/06_queue_bfs_grid/shortest_path_grid.py
@@ -1,0 +1,20 @@
+"""Exercise 06: BFS shortest path on a binary grid.
+
+Grid cells: 0 = open, 1 = blocked.
+
+TODO:
+- Return shortest number of steps from start to goal using 4-neighbor moves.
+- Return -1 if unreachable.
+"""
+
+
+def shortest_path_grid(grid: list[list[int]], start: tuple[int, int], goal: tuple[int, int]) -> int:
+    # TODO
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    grid = [[0, 0, 1], [1, 0, 1], [0, 0, 0]]
+    assert shortest_path_grid(grid, (0, 0), (2, 2)) == 4
+    assert shortest_path_grid(grid, (0, 0), (2, 0)) == -1
+    print("ok")

--- a/algolings/exercises/07_merge_intervals/merge_intervals.py
+++ b/algolings/exercises/07_merge_intervals/merge_intervals.py
@@ -1,0 +1,17 @@
+"""Exercise 07: merge intervals.
+
+TODO:
+- Given [start, end] intervals, merge overlaps.
+- Return merged intervals sorted by start.
+"""
+
+
+def merge_intervals(intervals: list[list[int]]) -> list[list[int]]:
+    # TODO
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    assert merge_intervals([[1, 3], [2, 6], [8, 10]]) == [[1, 6], [8, 10]]
+    assert merge_intervals([[1, 2], [3, 4]]) == [[1, 2], [3, 4]]
+    print("ok")

--- a/algolings/exercises/08_topological_sort/toposort.py
+++ b/algolings/exercises/08_topological_sort/toposort.py
@@ -1,0 +1,19 @@
+"""Exercise 08: topological sorting with Kahn's algorithm.
+
+TODO:
+- Input: number of nodes n, directed edges u->v.
+- Return a valid topological ordering as a list of length n.
+- Return [] if a cycle exists.
+"""
+
+
+def toposort(n: int, edges: list[tuple[int, int]]) -> list[int]:
+    # TODO
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    order = toposort(4, [(0, 1), (0, 2), (1, 3), (2, 3)])
+    assert order[0] == 0 and order[-1] == 3 and len(order) == 4
+    assert toposort(2, [(0, 1), (1, 0)]) == []
+    print("ok")

--- a/algolings/exercises/09_union_find_intro/union_find.py
+++ b/algolings/exercises/09_union_find_intro/union_find.py
@@ -1,0 +1,32 @@
+"""Exercise 09: union-find (disjoint set union).
+
+TODO:
+- Complete DSU with path compression + union by rank/size.
+- Support connected(a, b) queries.
+"""
+
+
+class UnionFind:
+    def __init__(self, n: int) -> None:
+        self.parent = list(range(n))
+        self.size = [1] * n
+
+    def find(self, x: int) -> int:
+        # TODO
+        raise NotImplementedError
+
+    def union(self, a: int, b: int) -> bool:
+        # TODO
+        raise NotImplementedError
+
+    def connected(self, a: int, b: int) -> bool:
+        return self.find(a) == self.find(b)
+
+
+if __name__ == "__main__":
+    uf = UnionFind(5)
+    uf.union(0, 1)
+    uf.union(1, 2)
+    assert uf.connected(0, 2) is True
+    assert uf.connected(0, 3) is False
+    print("ok")

--- a/algolings/exercises/10_dijkstra_shortest_path/dijkstra.py
+++ b/algolings/exercises/10_dijkstra_shortest_path/dijkstra.py
@@ -1,0 +1,23 @@
+"""Exercise 10: Dijkstra shortest path.
+
+TODO:
+- Graph is adjacency list: graph[u] = [(v, weight), ...].
+- Return distance from source to target, or -1 if unreachable.
+"""
+
+
+def dijkstra(graph: list[list[tuple[int, int]]], source: int, target: int) -> int:
+    # TODO
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    g = [
+        [(1, 4), (2, 1)],
+        [(3, 1)],
+        [(1, 2), (3, 5)],
+        [],
+    ]
+    assert dijkstra(g, 0, 3) == 4
+    assert dijkstra(g, 3, 0) == -1
+    print("ok")

--- a/algolings/exercises/11_dynamic_programming_lis/lis.py
+++ b/algolings/exercises/11_dynamic_programming_lis/lis.py
@@ -1,0 +1,16 @@
+"""Exercise 11: longest increasing subsequence length.
+
+TODO:
+- Return LIS length in O(n log n) using binary search on tails.
+"""
+
+
+def lis_length(nums: list[int]) -> int:
+    # TODO
+    raise NotImplementedError
+
+
+if __name__ == "__main__":
+    assert lis_length([10, 9, 2, 5, 3, 7, 101, 18]) == 4
+    assert lis_length([3, 3, 3]) == 1
+    print("ok")

--- a/algolings/solutions/00_find_first.py
+++ b/algolings/solutions/00_find_first.py
@@ -1,0 +1,5 @@
+def find_first(nums: list[int], target: int) -> int:
+    for i, value in enumerate(nums):
+        if value == target:
+            return i
+    return -1

--- a/algolings/solutions/01_binary_search.py
+++ b/algolings/solutions/01_binary_search.py
@@ -1,0 +1,11 @@
+def binary_search(nums: list[int], target: int) -> int:
+    left, right = 0, len(nums) - 1
+    while left <= right:
+        mid = (left + right) // 2
+        if nums[mid] == target:
+            return mid
+        if nums[mid] < target:
+            left = mid + 1
+        else:
+            right = mid - 1
+    return -1

--- a/algolings/solutions/02_two_sum.py
+++ b/algolings/solutions/02_two_sum.py
@@ -1,0 +1,8 @@
+def two_sum(nums: list[int], target: int) -> tuple[int, int]:
+    seen: dict[int, int] = {}
+    for i, value in enumerate(nums):
+        need = target - value
+        if need in seen:
+            return (seen[need], i)
+        seen[value] = i
+    return (-1, -1)

--- a/algolings/solutions/03_range_sum.py
+++ b/algolings/solutions/03_range_sum.py
@@ -1,0 +1,9 @@
+def build_prefix(nums: list[int]) -> list[int]:
+    prefix = [0]
+    for n in nums:
+        prefix.append(prefix[-1] + n)
+    return prefix
+
+
+def range_sum(prefix: list[int], left: int, right: int) -> int:
+    return prefix[right + 1] - prefix[left]

--- a/algolings/solutions/04_max_window_sum.py
+++ b/algolings/solutions/04_max_window_sum.py
@@ -1,0 +1,9 @@
+def max_window_sum(nums: list[int], k: int) -> int:
+    if k <= 0 or k > len(nums):
+        return 0
+    current = sum(nums[:k])
+    best = current
+    for i in range(k, len(nums)):
+        current += nums[i] - nums[i - k]
+        best = max(best, current)
+    return best

--- a/algolings/solutions/05_is_balanced.py
+++ b/algolings/solutions/05_is_balanced.py
@@ -1,0 +1,10 @@
+def is_balanced(text: str) -> bool:
+    pairs = {')': '(', ']': '[', '}': '{'}
+    stack: list[str] = []
+    for ch in text:
+        if ch in "([{":
+            stack.append(ch)
+        elif ch in pairs:
+            if not stack or stack.pop() != pairs[ch]:
+                return False
+    return not stack

--- a/algolings/solutions/06_shortest_path_grid.py
+++ b/algolings/solutions/06_shortest_path_grid.py
@@ -1,0 +1,24 @@
+from collections import deque
+
+
+def shortest_path_grid(grid: list[list[int]], start: tuple[int, int], goal: tuple[int, int]) -> int:
+    rows, cols = len(grid), len(grid[0])
+    sr, sc = start
+    gr, gc = goal
+    if grid[sr][sc] == 1 or grid[gr][gc] == 1:
+        return -1
+
+    q = deque([(sr, sc, 0)])
+    seen = {(sr, sc)}
+    directions = ((1, 0), (-1, 0), (0, 1), (0, -1))
+
+    while q:
+        r, c, dist = q.popleft()
+        if (r, c) == (gr, gc):
+            return dist
+        for dr, dc in directions:
+            nr, nc = r + dr, c + dc
+            if 0 <= nr < rows and 0 <= nc < cols and grid[nr][nc] == 0 and (nr, nc) not in seen:
+                seen.add((nr, nc))
+                q.append((nr, nc, dist + 1))
+    return -1

--- a/algolings/solutions/07_merge_intervals.py
+++ b/algolings/solutions/07_merge_intervals.py
@@ -1,0 +1,11 @@
+def merge_intervals(intervals: list[list[int]]) -> list[list[int]]:
+    if not intervals:
+        return []
+    intervals.sort(key=lambda x: x[0])
+    merged = [intervals[0][:]]
+    for start, end in intervals[1:]:
+        if start <= merged[-1][1]:
+            merged[-1][1] = max(merged[-1][1], end)
+        else:
+            merged.append([start, end])
+    return merged

--- a/algolings/solutions/08_toposort.py
+++ b/algolings/solutions/08_toposort.py
@@ -1,0 +1,22 @@
+from collections import deque
+
+
+def toposort(n: int, edges: list[tuple[int, int]]) -> list[int]:
+    graph = [[] for _ in range(n)]
+    indegree = [0] * n
+    for u, v in edges:
+        graph[u].append(v)
+        indegree[v] += 1
+
+    q = deque(i for i in range(n) if indegree[i] == 0)
+    order: list[int] = []
+
+    while q:
+        node = q.popleft()
+        order.append(node)
+        for nxt in graph[node]:
+            indegree[nxt] -= 1
+            if indegree[nxt] == 0:
+                q.append(nxt)
+
+    return order if len(order) == n else []

--- a/algolings/solutions/09_union_find.py
+++ b/algolings/solutions/09_union_find.py
@@ -1,0 +1,22 @@
+class UnionFind:
+    def __init__(self, n: int) -> None:
+        self.parent = list(range(n))
+        self.size = [1] * n
+
+    def find(self, x: int) -> int:
+        if self.parent[x] != x:
+            self.parent[x] = self.find(self.parent[x])
+        return self.parent[x]
+
+    def union(self, a: int, b: int) -> bool:
+        ra, rb = self.find(a), self.find(b)
+        if ra == rb:
+            return False
+        if self.size[ra] < self.size[rb]:
+            ra, rb = rb, ra
+        self.parent[rb] = ra
+        self.size[ra] += self.size[rb]
+        return True
+
+    def connected(self, a: int, b: int) -> bool:
+        return self.find(a) == self.find(b)

--- a/algolings/solutions/10_dijkstra.py
+++ b/algolings/solutions/10_dijkstra.py
@@ -1,0 +1,21 @@
+import heapq
+
+
+def dijkstra(graph: list[list[tuple[int, int]]], source: int, target: int) -> int:
+    dist = [float("inf")] * len(graph)
+    dist[source] = 0
+    heap: list[tuple[int, int]] = [(0, source)]
+
+    while heap:
+        d, node = heapq.heappop(heap)
+        if d > dist[node]:
+            continue
+        if node == target:
+            return d
+        for nxt, w in graph[node]:
+            nd = d + w
+            if nd < dist[nxt]:
+                dist[nxt] = nd
+                heapq.heappush(heap, (nd, nxt))
+
+    return -1

--- a/algolings/solutions/11_lis.py
+++ b/algolings/solutions/11_lis.py
@@ -1,0 +1,12 @@
+import bisect
+
+
+def lis_length(nums: list[int]) -> int:
+    tails: list[int] = []
+    for x in nums:
+        idx = bisect.bisect_left(tails, x)
+        if idx == len(tails):
+            tails.append(x)
+        else:
+            tails[idx] = x
+    return len(tails)


### PR DESCRIPTION
### Motivation
- Provide a rustlings-style learning track focused on core algorithms that progresses from simple to complex and matches existing tracks in the repo. 
- Encourage hands-on practice with small, testable exercises for common interview and algorithmic topics.

### Description
- Add a new `algolings/` folder containing `README.md`, `EXERCISES.md`, and a `check.py` helper to enumerate exercises and TODOs. 
- Add `algolings/exercises/...` with 12 exercise stubs (00..11) covering linear search through LIS and matching `algolings/solutions/...` files with reference implementations. 
- Update the root `README.txt` to reference the new `algolings/` track. 
- Add a repository `.gitignore` to ignore Python bytecode and `__pycache__` artifacts.

### Testing
- Ran `python algolings/check.py` to list exercise TODO statuses and it completed successfully. 
- Ran `python -m compileall algolings/exercises algolings/solutions` to byte-compile the new modules and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3d540b5a8832eb6cf2d5c7b34dc6d)