### PR TITLE
Add beginner-to-advanced chemistry LLM exercise track (exercises 89–94)

### DIFF
--- a/pytorchlings/EXERCISES.md
+++ b/pytorchlings/EXERCISES.md
@@ -103,3 +103,9 @@
 | 86 | PyTorch | Mixture-of-Experts multimodal router | `exercises/86_moe_multimodal_router/moe_multimodal_router.py` | `solutions/86_moe_multimodal_router.py` |
 | 87 | Lightning | Callback stack (EarlyStopping, checkpointing, LR monitor) | `exercises/87_lightning_callbacks/callbacks_and_early_stopping.py` | `solutions/87_callbacks_and_early_stopping.py` |
 | 88 | PyTorch | Scaled dot-product attention from scratch + causal masking | `exercises/88_attention_mechanics/scaled_dot_product_attention.py` | `solutions/88_scaled_dot_product_attention.py` |
+| 89 | PyTorch + NLP | Chemistry corpus tokenization + LM window construction | `exercises/89_chem_llm_tokenization/chem_corpus_tokenization.py` | `N/A (exercise scaffold)` |
+| 90 | PyTorch + NLP | Tiny decoder-only LM with causal masking | `exercises/90_tiny_decoder_lm/tiny_decoder_lm.py` | `N/A (exercise scaffold)` |
+| 91 | PyTorch + LLM | Chemistry instruction SFT with response-only masking | `exercises/91_chem_instruction_sft/chem_instruction_sft.py` | `N/A (exercise scaffold)` |
+| 92 | Retrieval + LLM | Chemistry RAG retrieval + grounded prompt construction | `exercises/92_chem_rag_basics/chem_rag_pipeline.py` | `N/A (exercise scaffold)` |
+| 93 | Post-training | Direct Preference Optimization (DPO) objective mechanics | `exercises/93_chem_preference_optimization/direct_preference_optimization.py` | `N/A (exercise scaffold)` |
+| 94 | Multimodal | Text + descriptor adapter for chemistry property prediction | `exercises/94_chem_llm_multimodal_adapter/chem_multimodal_adapter.py` | `N/A (exercise scaffold)` |

--- a/pytorchlings/README.md
+++ b/pytorchlings/README.md
@@ -29,6 +29,7 @@ A rustlings-style practice track for **PyTorch** and **PyTorch Geometric (PyG)**
 - Continue 79-82 to reuse earlier building blocks in progressively more complex architectures: hybrid fusion, residual MPNNs, cross-attention fusion, and multimodal uncertainty modeling.
 - Extend 83-86 for deeper architectural composition in the pytorchlings folder: residual MLP backbones, CNN-transformer hybrids, graph-sequence co-encoders, and multimodal MoE routing.
 - Extend 87-88 for practical Lightning callback orchestration and first-principles attention mechanics.
+- Extend 89-94 for a beginner-to-advanced chemistry LLM path: tokenization/data prep, decoder pretraining, instruction tuning, RAG grounding, preference optimization, and multimodal fusion.
 
 ## Quick check command
 
@@ -142,4 +143,18 @@ Exercises 87-88 add focused numerical drills requested for Lightning and attenti
 
 - 87: configure a production-relevant Lightning callback stack (EarlyStopping, checkpointing, LR monitoring)
 - 88: implement scaled dot-product attention and causal masking from scratch to build attention intuition
+
+
+## Chemistry LLM development path (beginner -> advanced)
+
+Exercises 89-94 were added to create a step-by-step path for learners who want to start from the basics and bridge toward advanced chemistry-focused LLM engineering:
+
+- 89: build a tiny chemistry corpus pipeline (vocab + tokenization + autoregressive windows)
+- 90: implement a decoder-only LM with causal masking from scratch
+- 91: practice instruction tuning data formatting and response-only SFT masking
+- 92: implement a lightweight retrieval workflow and grounded prompting (RAG basics)
+- 93: implement Direct Preference Optimization (DPO) objective mechanics
+- 94: fuse text representations with molecular descriptors in a multimodal adapter
+
+This sequence is intentionally cumulative: each exercise reuses skills from prior steps so beginners can move from fundamentals to realistic chemistry LLM components.
 

--- a/pytorchlings/exercises/89_chem_llm_tokenization/chem_corpus_tokenization.py
+++ b/pytorchlings/exercises/89_chem_llm_tokenization/chem_corpus_tokenization.py
@@ -1,0 +1,62 @@
+"""Exercise 89: tokenization + dataset prep for chemistry LLM work.
+
+Goal:
+- start from first principles: turn a tiny chemistry corpus into model-ready tensors
+- compare simple character tokenization with domain-aware tokenization ideas
+- build train/validation windows for autoregressive next-token prediction
+"""
+
+from __future__ import annotations
+
+import random
+
+import torch
+
+
+def build_char_vocab(texts: list[str]) -> tuple[dict[str, int], dict[int, str]]:
+    """Return (stoi, itos) including special tokens.
+
+    Special tokens:
+    - <pad>: 0
+    - <bos>: 1
+    - <eos>: 2
+    """
+    # TODO: collect unique characters from texts and build stoi/itos.
+    # Keep ordering deterministic (e.g., sorted chars).
+    stoi = {"<pad>": 0, "<bos>": 1, "<eos>": 2}
+    itos = {v: k for k, v in stoi.items()}
+    return stoi, itos
+
+
+def encode_sequence(seq: str, stoi: dict[str, int]) -> list[int]:
+    # TODO: encode with <bos> at start and <eos> at end.
+    return [stoi["<bos>"], stoi["<eos>"]]
+
+
+def build_lm_windows(encoded: list[int], block_size: int) -> tuple[torch.Tensor, torch.Tensor]:
+    """Build next-token windows (x, y) where y is x shifted by one token."""
+    xs: list[list[int]] = []
+    ys: list[list[int]] = []
+    # TODO: create sliding windows of length block_size over encoded tokens.
+    if not xs:
+        x = torch.zeros((0, block_size), dtype=torch.long)
+        y = torch.zeros((0, block_size), dtype=torch.long)
+        return x, y
+    return torch.tensor(xs, dtype=torch.long), torch.tensor(ys, dtype=torch.long)
+
+
+if __name__ == "__main__":
+    random.seed(89)
+    torch.manual_seed(89)
+
+    corpus = ["CCO", "N#N", "C(=O)O", "CCN", "ClCCl", "c1ccccc1"]
+    stoi, itos = build_char_vocab(corpus)
+    assert stoi["<pad>"] == 0 and itos[0] == "<pad>"
+
+    stream = []
+    for s in corpus:
+        stream.extend(encode_sequence(s, stoi))
+
+    x, y = build_lm_windows(stream, block_size=8)
+    print("x shape:", tuple(x.shape), "y shape:", tuple(y.shape))
+    print("exercise 89 scaffold ready")

--- a/pytorchlings/exercises/90_tiny_decoder_lm/tiny_decoder_lm.py
+++ b/pytorchlings/exercises/90_tiny_decoder_lm/tiny_decoder_lm.py
@@ -1,0 +1,57 @@
+"""Exercise 90: tiny decoder-only LM from scratch for chemistry strings.
+
+Goal:
+- implement causal self-attention masking
+- train a tiny autoregressive transformer on toy SMILES-like text
+- understand the basic training loop behind modern LLMs
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+
+class TinyDecoderLM(nn.Module):
+    def __init__(self, vocab_size: int, d_model: int = 64, nhead: int = 4, layers: int = 2, block_size: int = 16):
+        super().__init__()
+        self.block_size = block_size
+        self.tok = nn.Embedding(vocab_size, d_model)
+        self.pos = nn.Embedding(block_size, d_model)
+        enc_layer = nn.TransformerEncoderLayer(d_model=d_model, nhead=nhead, batch_first=True)
+        self.decoder = nn.TransformerEncoder(enc_layer, num_layers=layers)
+        self.head = nn.Linear(d_model, vocab_size)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        b, t = x.shape
+        pos_ids = torch.arange(t, device=x.device).unsqueeze(0)
+        h = self.tok(x) + self.pos(pos_ids)
+
+        # TODO: create a causal mask so position i cannot attend to j > i.
+        # Expected mask shape for nn.TransformerEncoder with batch_first=True: [t, t].
+        causal_mask = None
+
+        h = self.decoder(h, mask=causal_mask)
+        return self.head(h)
+
+
+def lm_loss(logits: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+    # TODO: flatten [B, T, V] and [B, T] to compute cross entropy.
+    return F.cross_entropy(torch.zeros((1, logits.size(-1))), torch.zeros((1,), dtype=torch.long))
+
+
+if __name__ == "__main__":
+    torch.manual_seed(90)
+
+    vocab_size = 32
+    x = torch.randint(0, vocab_size, (4, 16))
+    y = torch.randint(0, vocab_size, (4, 16))
+
+    model = TinyDecoderLM(vocab_size=vocab_size)
+    logits = model(x)
+    assert logits.shape == (4, 16, vocab_size)
+
+    loss = lm_loss(logits, y)
+    print("loss:", float(loss.item()))
+    print("exercise 90 scaffold ready")

--- a/pytorchlings/exercises/91_chem_instruction_sft/chem_instruction_sft.py
+++ b/pytorchlings/exercises/91_chem_instruction_sft/chem_instruction_sft.py
@@ -1,0 +1,47 @@
+"""Exercise 91: supervised fine-tuning (SFT) for chemistry Q&A.
+
+Goal:
+- format instruction datasets with prompt/response pairs
+- apply response-only loss masking
+- run one train step for beginner-friendly instruction tuning
+"""
+
+from __future__ import annotations
+
+import torch
+
+IGNORE_INDEX = -100
+
+
+def build_prompt(example: dict[str, str]) -> str:
+    """Simple chat template."""
+    instr = example["instruction"].strip()
+    inp = example.get("input", "").strip()
+    out = example["output"].strip()
+    return f"<user> {instr}\n{inp}\n<assistant> {out}"
+
+
+def build_label_mask(token_ids: torch.Tensor, assistant_token_id: int) -> torch.Tensor:
+    """Keep labels only after the assistant token; mask earlier positions with IGNORE_INDEX."""
+    labels = token_ids.clone()
+    # TODO: find assistant_token_id position per sample.
+    # TODO: set prompt-side labels to IGNORE_INDEX.
+    return labels
+
+
+if __name__ == "__main__":
+    torch.manual_seed(91)
+
+    batch = torch.tensor(
+        [
+            [3, 4, 5, 2, 8, 9, 10],
+            [7, 1, 2, 6, 5, 4, 3],
+        ],
+        dtype=torch.long,
+    )
+    assistant_token_id = 2
+    labels = build_label_mask(batch, assistant_token_id)
+
+    assert labels.shape == batch.shape
+    print("labels sample:", labels[0].tolist())
+    print("exercise 91 scaffold ready")

--- a/pytorchlings/exercises/92_chem_rag_basics/chem_rag_pipeline.py
+++ b/pytorchlings/exercises/92_chem_rag_basics/chem_rag_pipeline.py
@@ -1,0 +1,61 @@
+"""Exercise 92: retrieval-augmented generation (RAG) basics for chemistry.
+
+Goal:
+- build a tiny retrieval index over chemistry notes
+- retrieve top-k passages for a user question
+- construct a grounded prompt context for an LLM
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+import math
+
+
+def tokenize(text: str) -> list[str]:
+    return [t.lower() for t in text.replace("/", " ").replace("-", " ").split()]
+
+
+def cosine_sim(a: Counter[str], b: Counter[str]) -> float:
+    keys = set(a) | set(b)
+    dot = sum(a[k] * b[k] for k in keys)
+    na = math.sqrt(sum(v * v for v in a.values()))
+    nb = math.sqrt(sum(v * v for v in b.values()))
+    if na == 0 or nb == 0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def retrieve_top_k(query: str, docs: list[str], k: int = 2) -> list[tuple[int, float]]:
+    q = Counter(tokenize(query))
+    scored: list[tuple[int, float]] = []
+    for i, doc in enumerate(docs):
+        d = Counter(tokenize(doc))
+        # TODO: replace placeholder with cosine_sim(q, d).
+        score = 0.0
+        scored.append((i, score))
+    scored.sort(key=lambda x: x[1], reverse=True)
+    return scored[:k]
+
+
+def build_grounded_prompt(question: str, docs: list[str], top_hits: list[tuple[int, float]]) -> str:
+    context = "\n".join([f"[doc {i}] {docs[i]}" for i, _ in top_hits])
+    # TODO: return a concise grounded prompt that includes context + question.
+    return f"Question: {question}\nContext:\n{context}"
+
+
+if __name__ == "__main__":
+    docs = [
+        "Ethanol has molecular formula C2H6O and is a polar solvent.",
+        "Benzene is aromatic and has six pi electrons.",
+        "Acetic acid is a weak acid commonly written as CH3COOH.",
+    ]
+    query = "Which molecule is aromatic?"
+
+    hits = retrieve_top_k(query, docs, k=2)
+    prompt = build_grounded_prompt(query, docs, hits)
+
+    assert len(hits) == 2
+    print("retrieved:", hits)
+    print(prompt)
+    print("exercise 92 scaffold ready")

--- a/pytorchlings/exercises/93_chem_preference_optimization/direct_preference_optimization.py
+++ b/pytorchlings/exercises/93_chem_preference_optimization/direct_preference_optimization.py
@@ -1,0 +1,39 @@
+"""Exercise 93: Direct Preference Optimization (DPO) mechanics.
+
+Goal:
+- understand chosen vs rejected response pairs
+- implement DPO-style objective from log-probabilities
+- connect post-training alignment to scientific assistant behavior
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def dpo_loss(
+    logp_policy_chosen: torch.Tensor,
+    logp_policy_rejected: torch.Tensor,
+    logp_ref_chosen: torch.Tensor,
+    logp_ref_rejected: torch.Tensor,
+    beta: float = 0.1,
+) -> torch.Tensor:
+    """Compute scalar DPO loss over a batch."""
+    # TODO: implement:
+    # logits = beta * ((logp_policy_chosen - logp_policy_rejected) - (logp_ref_chosen - logp_ref_rejected))
+    # loss = -log(sigmoid(logits)).mean()
+    return torch.tensor(0.0)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(93)
+
+    bsz = 4
+    policy_c = torch.randn(bsz)
+    policy_r = torch.randn(bsz)
+    ref_c = torch.randn(bsz)
+    ref_r = torch.randn(bsz)
+
+    loss = dpo_loss(policy_c, policy_r, ref_c, ref_r, beta=0.2)
+    print("dpo loss:", float(loss.item()))
+    print("exercise 93 scaffold ready")

--- a/pytorchlings/exercises/94_chem_llm_multimodal_adapter/chem_multimodal_adapter.py
+++ b/pytorchlings/exercises/94_chem_llm_multimodal_adapter/chem_multimodal_adapter.py
@@ -1,0 +1,49 @@
+"""Exercise 94: multimodal adapter - fuse text and molecular descriptors.
+
+Goal:
+- bridge from pure LLM text modeling to chemistry-aware multimodal modeling
+- concatenate text embedding with numeric molecular descriptors
+- predict a property or uncertainty-aware score
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+
+class ChemMultimodalAdapter(nn.Module):
+    def __init__(self, vocab_size: int, text_dim: int = 64, desc_dim: int = 16, hidden: int = 64):
+        super().__init__()
+        self.emb = nn.Embedding(vocab_size, text_dim)
+        self.desc_proj = nn.Linear(desc_dim, text_dim)
+        self.fusion = nn.Sequential(
+            nn.Linear(text_dim * 2, hidden),
+            nn.ReLU(),
+            nn.Linear(hidden, 1),
+        )
+
+    def forward(self, token_ids: torch.Tensor, descriptors: torch.Tensor) -> torch.Tensor:
+        # token_ids: [B, T], descriptors: [B, D]
+        tok = self.emb(token_ids)
+
+        # TODO: replace simple mean pooling with masked pooling over non-pad tokens.
+        text_vec = tok.mean(dim=1)
+        desc_vec = self.desc_proj(descriptors)
+
+        fused = torch.cat([text_vec, desc_vec], dim=-1)
+        return self.fusion(fused).squeeze(-1)
+
+
+if __name__ == "__main__":
+    torch.manual_seed(94)
+    bsz, t, vocab, d = 5, 12, 40, 16
+
+    x = torch.randint(0, vocab, (bsz, t))
+    descriptors = torch.randn(bsz, d)
+
+    model = ChemMultimodalAdapter(vocab_size=vocab, desc_dim=d)
+    y = model(x, descriptors)
+
+    assert y.shape == (bsz,)
+    print("exercise 94 scaffold ready")


### PR DESCRIPTION
### Motivation
- Provide a beginner-to-advanced, cumulative set of hands-on scaffolds that bridge basic tokenization and sequence modeling to practical LLM engineering patterns for chemistry-specific workflows.
- Give learners a stepwise path covering dataset prep, decoder LM internals, instruction SFT masking, RAG grounding, preference-optimization mechanics, and simple multimodal fusion so they can progress from fundamentals to applied chemistry LLM components.

### Description
- Add six new scaffold exercise files: `pytorchlings/exercises/89_chem_llm_tokenization/chem_corpus_tokenization.py`, `90_tiny_decoder_lm/tiny_decoder_lm.py`, `91_chem_instruction_sft/chem_instruction_sft.py`, `92_chem_rag_basics/chem_rag_pipeline.py`, `93_chem_preference_optimization/direct_preference_optimization.py`, and `94_chem_llm_multimodal_adapter/chem_multimodal_adapter.py` containing TODOs and beginner-friendly examples.
- Update the exercises index by adding entries for exercises `89–94` in `pytorchlings/EXERCISES.md` so the new track appears in the canonical mapping.
- Update `pytorchlings/README.md` to reference the new chemistry LLM progression and add a descriptive section `## Chemistry LLM development path (beginner -> advanced)` summarizing the sequence.
- Keep the new exercises scaffold-style with explicit TODOs and simple smoke-run examples to match the repository's rustlings-like pedagogy.

### Testing
- Ran `python -m compileall pytorchlings/exercises/89_chem_llm_tokenization pytorchlings/exercises/90_tiny_decoder_lm pytorchlings/exercises/91_chem_instruction_sft pytorchlings/exercises/92_chem_rag_basics pytorchlings/exercises/93_chem_preference_optimization pytorchlings/exercises/94_chem_llm_multimodal_adapter` and the compilation completed successfully with no syntax errors.
- No additional automated unit tests were added for the scaffolds since they intentionally contain `TODO` placeholders and lightweight smoke checks only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7c705646c832e9944bfc4925ee483)