### PR TITLE
Add pytorchlings exercises for core GNN failure modes

### DIFF
--- a/pytorchlings/EXERCISES.md
+++ b/pytorchlings/EXERCISES.md
@@ -109,3 +109,7 @@
 | 92 | Retrieval + LLM | Chemistry RAG retrieval + grounded prompt construction | `exercises/92_chem_rag_basics/chem_rag_pipeline.py` | `N/A (exercise scaffold)` |
 | 93 | Post-training | Direct Preference Optimization (DPO) objective mechanics | `exercises/93_chem_preference_optimization/direct_preference_optimization.py` | `N/A (exercise scaffold)` |
 | 94 | Multimodal | Text + descriptor adapter for chemistry property prediction | `exercises/94_chem_llm_multimodal_adapter/chem_multimodal_adapter.py` | `N/A (exercise scaffold)` |
+
+| 95 | PyG + Theory | Limited expressiveness failure lab | `exercises/95_gnn_expressiveness_failure/gnn_expressiveness_failure.py` | `N/A (exercise scaffold)` |
+| 96 | PyG + Theory | Oversmoothing failure lab | `exercises/96_gnn_oversmoothing_lab/gnn_oversmoothing_lab.py` | `N/A (exercise scaffold)` |
+| 97 | PyG + Theory | Oversquashing failure lab | `exercises/97_gnn_oversquashing_lab/gnn_oversquashing_lab.py` | `N/A (exercise scaffold)` |

--- a/pytorchlings/README.md
+++ b/pytorchlings/README.md
@@ -158,3 +158,12 @@ Exercises 89-94 were added to create a step-by-step path for learners who want t
 
 This sequence is intentionally cumulative: each exercise reuses skills from prior steps so beginners can move from fundamentals to realistic chemistry LLM components.
 
+
+
+## GNN failure modes extension
+
+Exercises 95-97 add focused labs for three commonly confused GNN failure modes:
+
+- 95: limited expressiveness (aggregation collisions, WL-style limits)
+- 96: oversmoothing (representation homogenization with depth)
+- 97: oversquashing (long-range information bottlenecks)

--- a/pytorchlings/exercises/95_gnn_expressiveness_failure/gnn_expressiveness_failure.py
+++ b/pytorchlings/exercises/95_gnn_expressiveness_failure/gnn_expressiveness_failure.py
@@ -1,0 +1,58 @@
+"""Exercise 95: Limited expressiveness in message-passing GNNs.
+
+Goals:
+- show collisions from weak neighborhood aggregators (mean/max)
+- implement a multiset-sensitive aggregator demo
+- connect behavior to 1-WL limitations on regular graph pairs
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+
+def aggregate_mean(values: list[float]) -> float:
+    return sum(values) / len(values)
+
+
+def aggregate_sum(values: list[float]) -> float:
+    return sum(values)
+
+
+def aggregate_max(values: list[float]) -> float:
+    return max(values)
+
+
+def multiset_signature(values: list[int]) -> tuple[tuple[int, int], ...]:
+    """Return a count-preserving signature for a multiset.
+
+    TODO:
+    - replace this baseline with a learnable MLP-over-sum style sketch, or
+      another injective multiset map inspired by GIN.
+    """
+    counts = Counter(values)
+    return tuple(sorted(counts.items()))
+
+
+def demo_neighbor_collision() -> None:
+    neigh_a = [1, 3]
+    neigh_b = [2, 2]
+
+    assert aggregate_mean(neigh_a) == aggregate_mean(neigh_b)
+    assert aggregate_sum(neigh_a) == aggregate_sum(neigh_b)
+    assert aggregate_max(neigh_a) != aggregate_max(neigh_b)
+
+    sig_a = multiset_signature(neigh_a)
+    sig_b = multiset_signature(neigh_b)
+    assert sig_a != sig_b
+
+    print("mean collision:", aggregate_mean(neigh_a), aggregate_mean(neigh_b))
+    print("sum collision:", aggregate_sum(neigh_a), aggregate_sum(neigh_b))
+    print("multiset signatures:", sig_a, sig_b)
+
+
+if __name__ == "__main__":
+    demo_neighbor_collision()
+    # TODO: add a tiny PyG experiment comparing GCNConv vs GINConv on a pair of
+    # non-isomorphic graphs that are hard for weak aggregators.
+    print("exercise 95 scaffold ready")

--- a/pytorchlings/exercises/96_gnn_oversmoothing_lab/gnn_oversmoothing_lab.py
+++ b/pytorchlings/exercises/96_gnn_oversmoothing_lab/gnn_oversmoothing_lab.py
@@ -1,0 +1,63 @@
+"""Exercise 96: Oversmoothing in deep message passing.
+
+Goals:
+- repeatedly propagate over a graph and measure feature collapse
+- track pairwise cosine similarity as depth increases
+- try residual/skip variants to reduce collapse
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+def row_normalize(adj: torch.Tensor) -> torch.Tensor:
+    deg = adj.sum(dim=1, keepdim=True).clamp(min=1.0)
+    return adj / deg
+
+
+def mean_propagation_step(x: torch.Tensor, p: torch.Tensor) -> torch.Tensor:
+    return p @ x
+
+
+def average_offdiag_cosine(x: torch.Tensor) -> float:
+    z = F.normalize(x, dim=-1)
+    sims = z @ z.T
+    n = sims.size(0)
+    mask = ~torch.eye(n, dtype=torch.bool)
+    return sims[mask].mean().item()
+
+
+def run_oversmoothing_demo(num_layers: int = 20) -> list[float]:
+    # 5-node line graph
+    adj = torch.tensor(
+        [
+            [1, 1, 0, 0, 0],
+            [1, 1, 1, 0, 0],
+            [0, 1, 1, 1, 0],
+            [0, 0, 1, 1, 1],
+            [0, 0, 0, 1, 1],
+        ],
+        dtype=torch.float32,
+    )
+
+    p = row_normalize(adj)
+    x = torch.eye(5)
+
+    smoothness = []
+    for _ in range(num_layers):
+        x = mean_propagation_step(x, p)
+        smoothness.append(average_offdiag_cosine(x))
+
+    return smoothness
+
+
+if __name__ == "__main__":
+    smoothness_curve = run_oversmoothing_demo(num_layers=20)
+    assert smoothness_curve[0] < smoothness_curve[-1], "expected similarity growth"
+
+    print("first 5 cosine means:", [round(v, 4) for v in smoothness_curve[:5]])
+    print("last 5 cosine means:", [round(v, 4) for v in smoothness_curve[-5:]])
+    # TODO: add residual mixing: x <- alpha*x0 + (1-alpha)*(P@x) and compare curves.
+    print("exercise 96 scaffold ready")

--- a/pytorchlings/exercises/97_gnn_oversquashing_lab/gnn_oversquashing_lab.py
+++ b/pytorchlings/exercises/97_gnn_oversquashing_lab/gnn_oversquashing_lab.py
@@ -1,0 +1,53 @@
+"""Exercise 97: Oversquashing and graph bottlenecks.
+
+Goals:
+- build a bottleneck graph where many sources route through one bridge node
+- compare information retention at the target as source count increases
+- test mitigation ideas (rewiring, virtual edges, global attention)
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+def bottleneck_aggregate(source_features: torch.Tensor) -> torch.Tensor:
+    """Compress many source vectors into one bridge message.
+
+    This intentionally uses mean aggregation to illustrate an information
+    bottleneck before forwarding to the target node.
+    """
+    return source_features.mean(dim=0)
+
+
+def retention_proxy(source_features: torch.Tensor) -> float:
+    """Heuristic: reconstruction error from only the bottleneck mean.
+
+    Lower is better. Error typically rises as source count/diversity rises.
+    """
+    bridge = bottleneck_aggregate(source_features)
+    recon = bridge.unsqueeze(0).expand_as(source_features)
+    mse = torch.mean((source_features - recon) ** 2).item()
+    return mse
+
+
+def run_bottleneck_scaling(dim: int = 16) -> list[tuple[int, float]]:
+    torch.manual_seed(0)
+    out = []
+    for n_sources in [2, 4, 8, 16, 32, 64]:
+        x = torch.randn(n_sources, dim)
+        out.append((n_sources, retention_proxy(x)))
+    return out
+
+
+if __name__ == "__main__":
+    scaling = run_bottleneck_scaling()
+    print("source_count -> bottleneck mse")
+    for n, err in scaling:
+        print(f"{n:>2} -> {err:.4f}")
+
+    # Monotonicity is not guaranteed for one sample, but broad trend should rise.
+    assert scaling[0][1] < scaling[-1][1]
+    # TODO: add rewiring experiment: split sources across multiple bridge nodes and
+    # compare bottleneck MSE to single-bridge baseline.
+    print("exercise 97 scaffold ready")


### PR DESCRIPTION
### Motivation

- Provide focused, hands-on scaffolds that teach three distinct GNN failure modes (limited expressiveness, oversmoothing, oversquashing) so learners can experiment and distinguish the concepts. 
- Address common confusion in graph ML pedagogy by giving small reproducible demos that illustrate aggregation collisions, feature collapse with depth, and bottleneck compression. 
- Target chemistry/biomolecular practitioners who need to reason about graph representation limits and long-range interactions in molecular problems.

### Description

- Add `pytorchlings/exercises/95_gnn_expressiveness_failure/gnn_expressiveness_failure.py` which demonstrates mean/sum collisions, a simple multiset signature baseline, and TODO hooks for a GCN vs GIN follow-up. 
- Add `pytorchlings/exercises/96_gnn_oversmoothing_lab/gnn_oversmoothing_lab.py` which repeatedly propagates features on a small line graph and measures average off-diagonal cosine similarity to quantify oversmoothing. 
- Add `pytorchlings/exercises/97_gnn_oversquashing_lab/gnn_oversquashing_lab.py` which builds a bridge-bottleneck proxy and reports a reconstruction MSE as source count scales to illustrate oversquashing. 
- Update `pytorchlings/EXERCISES.md` to include entries `95-97` and update `pytorchlings/README.md` with a `GNN failure modes extension` section describing the new labs.

### Testing

- Ran `python -m compileall pytorchlings/exercises/95_gnn_expressiveness_failure pytorchlings/exercises/96_gnn_oversmoothing_lab pytorchlings/exercises/97_gnn_oversquashing_lab` and the three new modules compiled successfully. 
- No additional unit tests were added; the exercises include simple runtime assertions and TODOs for follow-up PyG experiments.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148a895240832e87df2ee46a813a86)