### PR TITLE
Add systems-minded Python exercises

### DIFF
--- a/py03lings/EXERCISES.md
+++ b/py03lings/EXERCISES.md
@@ -1,5 +1,7 @@
 # Exercise List (with solution mapping)
 
+## Core Python fundamentals
+
 | # | Topic | Exercise File | Solution File |
 |---|---|---|---|
 | 00 | f-strings and joins | `exercises/00_string_builder/string_builder.py` | `solutions/00_string_builder.py` |
@@ -7,71 +9,47 @@
 | 02 | list/dict transformations | `exercises/02_collections/collections_ops.py` | `solutions/02_collections_ops.py` |
 | 03 | function defaults and kwargs | `exercises/03_functions/keyword_report.py` | `solutions/03_keyword_report.py` |
 
+## Async foundations
+
+| # | Topic | Exercise File | Solution File |
+|---|---|---|---|
 | 04 | asyncio basics (`async`/`await`) | `exercises/04_async_sleep/async_sleep.py` | `solutions/04_async_sleep.py` |
 | 05 | async concurrency with `gather` | `exercises/05_async_gather/async_gather.py` | `solutions/05_async_gather.py` |
 
+## Data modeling and validation
+
+| # | Topic | Exercise File | Solution File |
+|---|---|---|---|
 | 06 | dataclasses intro | `exercises/06_dataclasses_intro/student_record.py` | `solutions/06_student_record.py` |
 | 07 | staticmethod factories | `exercises/07_staticmethod_factory/temperature.py` | `solutions/07_temperature.py` |
 | 08 | pydantic model validation | `exercises/08_pydantic_models/order_model.py` | `solutions/08_order_model.py` |
 | 09 | dataclass + staticmethod + pydantic | `exercises/09_dataclass_staticmethod_pydantic/inventory_bridge.py` | `solutions/09_inventory_bridge.py` |
 
+## Object orientation methods (basic to advanced)
+
+| # | Topic | Exercise File | Solution File |
+|---|---|---|---|
+| 10 | instance methods and class methods | `exercises/10_instance_class_methods/bank_account.py` | `solutions/10_instance_class_methods.py` |
+| 11 | dunder methods (`__repr__`, `__add__`, `__eq__`) | `exercises/11_dunder_methods/vector2d.py` | `solutions/11_dunder_methods.py` |
+| 12 | abstract methods and polymorphism (ABC) | `exercises/12_abstract_methods/shape_pricing.py` | `solutions/12_abstract_methods.py` |
+| 13 | mixins and `super()` method reuse | `exercises/13_mixin_super_calls/notifications.py` | `solutions/13_mixin_super_calls.py` |
+
+## Practical data engineering patterns
+
+| # | Topic | Exercise File | Solution File |
+|---|---|---|---|
 | 10 | data modeling + contracts | `exercises/10_data_modeling_contracts/data_contracts.py` | `solutions/10_data_contracts.py` |
 | 11 | transformations + partitioning | `exercises/11_transformation_partitioning/partition_transform.py` | `solutions/11_partition_transform.py` |
 | 12 | orchestration + SLA reporting | `exercises/12_orchestration_slas/orchestrate_pipeline.py` | `solutions/12_orchestrate_pipeline.py` |
 | 13 | cloud-native architecture choices | `exercises/13_cloud_native_architecture/cloud_architecture.py` | `solutions/13_cloud_architecture.py` |
 | 14 | governance, lineage, and access checks | `exercises/14_governance_lineage_access/governance_checks.py` | `solutions/14_governance_checks.py` |
 | 15 | cost optimization + performance tuning | `exercises/15_cost_perf_tuning/cost_perf_tuning.py` | `solutions/15_cost_perf_tuning.py` |
-=======
-## Core Python fundamentals
 
-1. **00 — f-strings and joins**  
-   Exercise: `exercises/00_string_builder/string_builder.py`  
-   Solution: `solutions/00_string_builder.py`
-2. **01 — conditionals and loops**  
-   Exercise: `exercises/01_control_flow/control_flow.py`  
-   Solution: `solutions/01_control_flow.py`
-3. **02 — list/dict transformations**  
-   Exercise: `exercises/02_collections/collections_ops.py`  
-   Solution: `solutions/02_collections_ops.py`
-4. **03 — function defaults and kwargs**  
-   Exercise: `exercises/03_functions/keyword_report.py`  
-   Solution: `solutions/03_keyword_report.py`
+## Computer science systems fundamentals
 
-## Async foundations
-
-5. **04 — asyncio basics (`async`/`await`)**  
-   Exercise: `exercises/04_async_sleep/async_sleep.py`  
-   Solution: `solutions/04_async_sleep.py`
-6. **05 — async concurrency with `gather`**  
-   Exercise: `exercises/05_async_gather/async_gather.py`  
-   Solution: `solutions/05_async_gather.py`
-
-## Data modeling and validation
-
-7. **06 — dataclasses intro**  
-   Exercise: `exercises/06_dataclasses_intro/student_record.py`  
-   Solution: `solutions/06_student_record.py`
-8. **07 — staticmethod factories**  
-   Exercise: `exercises/07_staticmethod_factory/temperature.py`  
-   Solution: `solutions/07_temperature.py`
-9. **08 — pydantic model validation**  
-   Exercise: `exercises/08_pydantic_models/order_model.py`  
-   Solution: `solutions/08_order_model.py`
-10. **09 — dataclass + staticmethod + pydantic**  
-    Exercise: `exercises/09_dataclass_staticmethod_pydantic/inventory_bridge.py`  
-    Solution: `solutions/09_inventory_bridge.py`
-
-## Object orientation methods (basic → advanced)
-
-11. **10 — instance methods and class methods**  
-    Exercise: `exercises/10_instance_class_methods/bank_account.py`  
-    Solution: `solutions/10_instance_class_methods.py`
-12. **11 — dunder methods (`__repr__`, `__add__`, `__eq__`)**  
-    Exercise: `exercises/11_dunder_methods/vector2d.py`  
-    Solution: `solutions/11_dunder_methods.py`
-13. **12 — abstract methods and polymorphism (ABC)**  
-    Exercise: `exercises/12_abstract_methods/shape_pricing.py`  
-    Solution: `solutions/12_abstract_methods.py`
-14. **13 — mixins and `super()` method reuse**  
-    Exercise: `exercises/13_mixin_super_calls/notifications.py`  
-    Solution: `solutions/13_mixin_super_calls.py`
+| # | Topic | Exercise File | Solution File |
+|---|---|---|---|
+| 16 | `__slots__` and per-instance memory overhead | `exercises/16_slots_memory/profile_records.py` | `solutions/16_profile_records.py` |
+| 17 | choosing `deque` vs `list` for queues and rotation | `exercises/17_deque_work_queue/work_queue.py` | `solutions/17_work_queue.py` |
+| 18 | virtual pages and LRU memory pressure simulation | `exercises/18_memory_pages/page_cache.py` | `solutions/18_page_cache.py` |
+| 19 | kernel-style round-robin scheduling and time slices | `exercises/19_scheduler_timeslices/scheduler.py` | `solutions/19_scheduler.py` |

--- a/py03lings/README.md
+++ b/py03lings/README.md
@@ -15,6 +15,7 @@ A rustlings-style practice track for Python 3 fundamentals, async exercises, and
 - Continue 04-05 for async foundations.
 - Work through 06-09 for dataclasses and validation.
 - Finish 10-15 for practical data engineering patterns (modeling, partitioning, orchestration, governance, and performance).
+- Use 16-19 to practice systems-minded Python: `__slots__`, `deque`, page/cache behavior, and scheduler time slices.
 
 ## Quick check commands
 

--- a/py03lings/exercises/16_slots_memory/profile_records.py
+++ b/py03lings/exercises/16_slots_memory/profile_records.py
@@ -1,0 +1,36 @@
+"""Exercise 16: use __slots__ when many tiny Python objects need less overhead.
+
+The goal is not to make every class slotted. Use slots when instances are
+numerous, attribute names are fixed, and you do not need a per-instance
+``__dict__`` for dynamic attributes.
+"""
+
+
+class PacketSample:
+    # TODO: add __slots__ for sensor_id, sequence, and payload_size_bytes.
+
+    def __init__(self, sensor_id: str, sequence: int, payload_size_bytes: int) -> None:
+        # TODO: assign the three constructor arguments to instance attributes.
+        pass
+
+    def estimated_wire_bytes(self) -> int:
+        """Return the payload plus a tiny fixed header estimate."""
+        # TODO: each packet has a 16-byte header in addition to the payload.
+        return 0
+
+
+def has_per_instance_dict(obj: object) -> bool:
+    """Return True when obj still has a normal per-instance __dict__."""
+    # TODO: slotted instances without "__dict__" in __slots__ should return False.
+    return True
+
+
+def summarize(samples: list[PacketSample]) -> dict[str, int | bool]:
+    """Summarize a batch without adding dynamic attributes to each sample."""
+    # TODO: return count, total_wire_bytes, and uses_instance_dict.
+    return {"count": 0, "total_wire_bytes": 0, "uses_instance_dict": True}
+
+
+if __name__ == "__main__":
+    batch = [PacketSample("temperature", 1, 128), PacketSample("pressure", 2, 64)]
+    print(summarize(batch))

--- a/py03lings/exercises/17_deque_work_queue/work_queue.py
+++ b/py03lings/exercises/17_deque_work_queue/work_queue.py
@@ -1,0 +1,41 @@
+"""Exercise 17: choose deque when queue operations happen at both ends.
+
+Lists are excellent dynamic arrays. A deque is the right default for FIFO
+queues, bounded recent-history buffers, and round-robin rotation because
+``popleft`` and appends at either end are O(1).
+"""
+
+from collections import deque
+
+def drain_fifo(events: list[str]) -> list[str]:
+    """Process events in arrival order without repeatedly popping index 0."""
+    # TODO: load events into a deque, then repeatedly popleft until empty.
+    processed: list[str] = []
+    return processed
+
+
+def last_n_events(events: list[str], n: int) -> list[str]:
+    """Return the most recent n events using a bounded deque."""
+    # TODO: use deque(maxlen=n) so old entries fall out automatically.
+    return []
+
+
+def round_robin(workers: list[str], steps: int) -> list[str]:
+    """Return the worker selected at each step, rotating fairly after each pick."""
+    # TODO: use a deque; pick the left worker, append/rotate it to the back.
+    schedule: list[str] = []
+    return schedule
+
+
+def queue_type_for(operation: str) -> str:
+    """Explain whether list or deque is the better fit for common operations."""
+    # TODO: return "deque" for fifo, lifo_with_left_end, and round_robin.
+    # TODO: return "list" for random_indexing and append_only_scan.
+    # TODO: raise ValueError for unknown operations.
+    return "list"
+
+
+if __name__ == "__main__":
+    print(drain_fifo(["connect", "read", "write"]))
+    print(last_n_events(["a", "b", "c", "d"], 2))
+    print(round_robin(["cpu0", "cpu1", "cpu2"], 5))

--- a/py03lings/exercises/18_memory_pages/page_cache.py
+++ b/py03lings/exercises/18_memory_pages/page_cache.py
@@ -1,0 +1,54 @@
+"""Exercise 18: model virtual pages and a tiny LRU page cache.
+
+Operating systems move memory in pages. This exercise is a small simulation:
+translate byte addresses to page numbers, track cache hits, and evict the
+least-recently-used page when physical capacity is exceeded.
+"""
+
+from collections import OrderedDict
+
+PAGE_SIZE_BYTES = 4096
+
+
+def page_number(address: int) -> int:
+    """Return the zero-based virtual page containing address."""
+    # TODO: reject negative addresses with ValueError.
+    # TODO: use integer floor division by PAGE_SIZE_BYTES.
+    return 0
+
+
+def page_offset(address: int) -> int:
+    """Return the byte offset inside the page containing address."""
+    # TODO: reject negative addresses with ValueError.
+    # TODO: use modulo PAGE_SIZE_BYTES.
+    return 0
+
+
+class LruPageCache:
+    def __init__(self, capacity_pages: int) -> None:
+        # TODO: reject capacities less than 1.
+        self.capacity_pages = capacity_pages
+        self._pages: OrderedDict[int, None] = OrderedDict()
+
+    def access(self, address: int) -> bool:
+        """Access address, returning True for a cache hit and False for a miss."""
+        # TODO: translate address to a page.
+        # TODO: on hit, move the page to the most-recently-used end and return True.
+        # TODO: on miss, add the page and evict the least-recently-used page if needed.
+        return False
+
+    def resident_pages(self) -> list[int]:
+        """Return pages from least-recently-used to most-recently-used."""
+        # TODO: expose the current OrderedDict keys as a list.
+        return []
+
+
+def simulate_cache(addresses: list[int], capacity_pages: int) -> dict[str, object]:
+    """Return hit/miss counts and final resident pages."""
+    # TODO: run all accesses through LruPageCache.
+    return {"hits": 0, "misses": 0, "resident_pages": []}
+
+
+if __name__ == "__main__":
+    trace = [0, 8, 4096, 8192, 0, 4096, 12288]
+    print(simulate_cache(trace, capacity_pages=3))

--- a/py03lings/exercises/19_scheduler_timeslices/scheduler.py
+++ b/py03lings/exercises/19_scheduler_timeslices/scheduler.py
@@ -1,0 +1,56 @@
+"""Exercise 19: simulate a simple round-robin CPU scheduler.
+
+Real kernels account for priorities, blocking, wakeups, CPU affinity, and many
+hardware details. This deliberately small model focuses on a core idea:
+runnable threads get a time slice, unfinished work goes to the back of the run
+queue, and completion time depends on the chosen quantum.
+"""
+
+from collections import deque
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ThreadSpec:
+    name: str
+    cpu_time_ms: int
+
+
+@dataclass(frozen=True)
+class TimeSlice:
+    thread: str
+    start_ms: int
+    end_ms: int
+
+
+def validate_thread(thread: ThreadSpec) -> None:
+    # TODO: raise ValueError when name is empty or cpu_time_ms is less than 1.
+    return None
+
+
+def simulate_round_robin(threads: list[ThreadSpec], quantum_ms: int) -> list[TimeSlice]:
+    """Return the execution slices produced by a round-robin scheduler."""
+    # TODO: reject quantum_ms < 1.
+    # TODO: validate all threads.
+    # TODO: keep remaining CPU time in a deque of (ThreadSpec, remaining_ms).
+    # TODO: each slice runs min(quantum_ms, remaining_ms).
+    # TODO: append unfinished threads to the back of the queue.
+    return []
+
+
+def completion_times(slices: list[TimeSlice]) -> dict[str, int]:
+    """Return the final end time for each thread."""
+    # TODO: the last slice for a thread determines its completion time.
+    return {}
+
+
+def average_turnaround_ms(threads: list[ThreadSpec], quantum_ms: int) -> float:
+    """Assume all threads arrive at time 0 and return average completion time."""
+    # TODO: simulate, compute completion times, and average them.
+    return 0.0
+
+
+if __name__ == "__main__":
+    workload = [ThreadSpec("render", 5), ThreadSpec("io", 2), ThreadSpec("train", 7)]
+    print(simulate_round_robin(workload, quantum_ms=3))
+    print(average_turnaround_ms(workload, quantum_ms=3))

--- a/py03lings/solutions/16_profile_records.py
+++ b/py03lings/solutions/16_profile_records.py
@@ -1,0 +1,30 @@
+"""Solution 16: use __slots__ when many tiny Python objects need less overhead."""
+
+
+class PacketSample:
+    __slots__ = ("sensor_id", "sequence", "payload_size_bytes")
+
+    def __init__(self, sensor_id: str, sequence: int, payload_size_bytes: int) -> None:
+        self.sensor_id = sensor_id
+        self.sequence = sequence
+        self.payload_size_bytes = payload_size_bytes
+
+    def estimated_wire_bytes(self) -> int:
+        return self.payload_size_bytes + 16
+
+
+def has_per_instance_dict(obj: object) -> bool:
+    return hasattr(obj, "__dict__")
+
+
+def summarize(samples: list[PacketSample]) -> dict[str, int | bool]:
+    return {
+        "count": len(samples),
+        "total_wire_bytes": sum(sample.estimated_wire_bytes() for sample in samples),
+        "uses_instance_dict": any(has_per_instance_dict(sample) for sample in samples),
+    }
+
+
+if __name__ == "__main__":
+    batch = [PacketSample("temperature", 1, 128), PacketSample("pressure", 2, 64)]
+    print(summarize(batch))

--- a/py03lings/solutions/17_work_queue.py
+++ b/py03lings/solutions/17_work_queue.py
@@ -1,0 +1,43 @@
+"""Solution 17: choose deque when queue operations happen at both ends."""
+
+from collections import deque
+
+
+def drain_fifo(events: list[str]) -> list[str]:
+    queue = deque(events)
+    processed: list[str] = []
+    while queue:
+        processed.append(queue.popleft())
+    return processed
+
+
+def last_n_events(events: list[str], n: int) -> list[str]:
+    return list(deque(events, maxlen=n))
+
+
+def round_robin(workers: list[str], steps: int) -> list[str]:
+    if not workers or steps <= 0:
+        return []
+    queue = deque(workers)
+    schedule: list[str] = []
+    for _ in range(steps):
+        worker = queue.popleft()
+        schedule.append(worker)
+        queue.append(worker)
+    return schedule
+
+
+def queue_type_for(operation: str) -> str:
+    deque_ops = {"fifo", "lifo_with_left_end", "round_robin"}
+    list_ops = {"random_indexing", "append_only_scan"}
+    if operation in deque_ops:
+        return "deque"
+    if operation in list_ops:
+        return "list"
+    raise ValueError(f"unknown operation: {operation}")
+
+
+if __name__ == "__main__":
+    print(drain_fifo(["connect", "read", "write"]))
+    print(last_n_events(["a", "b", "c", "d"], 2))
+    print(round_robin(["cpu0", "cpu1", "cpu2"], 5))

--- a/py03lings/solutions/18_page_cache.py
+++ b/py03lings/solutions/18_page_cache.py
@@ -1,0 +1,55 @@
+"""Solution 18: model virtual pages and a tiny LRU page cache."""
+
+from collections import OrderedDict
+
+PAGE_SIZE_BYTES = 4096
+
+
+def page_number(address: int) -> int:
+    if address < 0:
+        raise ValueError("address must be non-negative")
+    return address // PAGE_SIZE_BYTES
+
+
+def page_offset(address: int) -> int:
+    if address < 0:
+        raise ValueError("address must be non-negative")
+    return address % PAGE_SIZE_BYTES
+
+
+class LruPageCache:
+    def __init__(self, capacity_pages: int) -> None:
+        if capacity_pages < 1:
+            raise ValueError("capacity_pages must be at least 1")
+        self.capacity_pages = capacity_pages
+        self._pages: OrderedDict[int, None] = OrderedDict()
+
+    def access(self, address: int) -> bool:
+        page = page_number(address)
+        if page in self._pages:
+            self._pages.move_to_end(page)
+            return True
+        self._pages[page] = None
+        if len(self._pages) > self.capacity_pages:
+            self._pages.popitem(last=False)
+        return False
+
+    def resident_pages(self) -> list[int]:
+        return list(self._pages.keys())
+
+
+def simulate_cache(addresses: list[int], capacity_pages: int) -> dict[str, object]:
+    cache = LruPageCache(capacity_pages)
+    hits = 0
+    misses = 0
+    for address in addresses:
+        if cache.access(address):
+            hits += 1
+        else:
+            misses += 1
+    return {"hits": hits, "misses": misses, "resident_pages": cache.resident_pages()}
+
+
+if __name__ == "__main__":
+    trace = [0, 8, 4096, 8192, 0, 4096, 12288]
+    print(simulate_cache(trace, capacity_pages=3))

--- a/py03lings/solutions/19_scheduler.py
+++ b/py03lings/solutions/19_scheduler.py
@@ -1,0 +1,68 @@
+"""Solution 19: simulate a simple round-robin CPU scheduler."""
+
+from collections import deque
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ThreadSpec:
+    name: str
+    cpu_time_ms: int
+
+
+@dataclass(frozen=True)
+class TimeSlice:
+    thread: str
+    start_ms: int
+    end_ms: int
+
+
+def validate_thread(thread: ThreadSpec) -> None:
+    if not thread.name:
+        raise ValueError("thread name must be non-empty")
+    if thread.cpu_time_ms < 1:
+        raise ValueError("cpu_time_ms must be at least 1")
+
+
+def simulate_round_robin(threads: list[ThreadSpec], quantum_ms: int) -> list[TimeSlice]:
+    if quantum_ms < 1:
+        raise ValueError("quantum_ms must be at least 1")
+    for thread in threads:
+        validate_thread(thread)
+
+    runnable = deque((thread, thread.cpu_time_ms) for thread in threads)
+    now_ms = 0
+    slices: list[TimeSlice] = []
+
+    while runnable:
+        thread, remaining_ms = runnable.popleft()
+        run_ms = min(quantum_ms, remaining_ms)
+        start_ms = now_ms
+        now_ms += run_ms
+        slices.append(TimeSlice(thread=thread.name, start_ms=start_ms, end_ms=now_ms))
+
+        remaining_ms -= run_ms
+        if remaining_ms > 0:
+            runnable.append((thread, remaining_ms))
+
+    return slices
+
+
+def completion_times(slices: list[TimeSlice]) -> dict[str, int]:
+    completed: dict[str, int] = {}
+    for time_slice in slices:
+        completed[time_slice.thread] = time_slice.end_ms
+    return completed
+
+
+def average_turnaround_ms(threads: list[ThreadSpec], quantum_ms: int) -> float:
+    if not threads:
+        return 0.0
+    completed = completion_times(simulate_round_robin(threads, quantum_ms))
+    return sum(completed[thread.name] for thread in threads) / len(threads)
+
+
+if __name__ == "__main__":
+    workload = [ThreadSpec("render", 5), ThreadSpec("io", 2), ThreadSpec("train", 7)]
+    print(simulate_round_robin(workload, quantum_ms=3))
+    print(average_turnaround_ms(workload, quantum_ms=3))


### PR DESCRIPTION
### Motivation

- Add short, focused exercises that teach systems-minded Python topics commonly needed by systems-aware engineers: `__slots__` memory tradeoffs, when to use `deque` vs `list`, virtual page/LRU cache behavior, and round-robin CPU scheduling. 
- Provide hands-on practice for developers who need to reason about memory, data structures, and scheduler behavior in Python code. 

### Description

- Add four exercise stubs under `py03lings/exercises/16_slots_memory`, `.../17_deque_work_queue`, `.../18_memory_pages`, and `.../19_scheduler_timeslices` that contain `TODO` prompts for the topics above. 
- Add matching solution implementations under `py03lings/solutions/16_profile_records.py`, `17_work_queue.py`, `18_page_cache.py`, and `19_scheduler.py` that implement the expected behavior and APIs used by the exercises. 
- Update `py03lings/EXERCISES.md` and `py03lings/README.md` to include a new "Computer science systems fundamentals" section and link the new exercises into the suggested flow. 

### Testing

- Ran `python py03lings/check.py` which lists exercises and counts `TODO`s; the check completed successfully. 
- Ran `python -m compileall py03lings/exercises py03lings/solutions` to ensure all new files compile under the target Python version, and compilation succeeded. 
- Executed a smoke test script (`python - <<'PY' ... PY`) that imports the new solution modules and asserts expected outputs for `summarize`, `drain_fifo`/`round_robin`, `simulate_cache`, and `simulate_round_robin`; all smoke checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1996607fb8832e83e58e41945c38af)