### PR TITLE
Add OOP sushi-conveyor exercises (py03lings 20–23)

### DIFF
--- a/py03lings/EXERCISES.md
+++ b/py03lings/EXERCISES.md
@@ -53,3 +53,15 @@
 | 17 | choosing `deque` vs `list` for queues and rotation | `exercises/17_deque_work_queue/work_queue.py` | `solutions/17_work_queue.py` |
 | 18 | virtual pages and LRU memory pressure simulation | `exercises/18_memory_pages/page_cache.py` | `solutions/18_page_cache.py` |
 | 19 | kernel-style round-robin scheduling and time slices | `exercises/19_scheduler_timeslices/scheduler.py` | `solutions/19_scheduler.py` |
+
+## Object-Oriented Python sushi simulator
+
+These exercises mirror a four-day OOP course arc: start with plain data that wants to become objects, then add Python's data model, design judgment around inheritance vs. composition, and finally properties/dataclasses/SOLID-style swappable behavior.
+
+| # | Topic | Exercise File | Solution File |
+|---|---|---|---|
+| 20 | classes, instances, `__repr__`, and mutable attribute traps | `exercises/20_oop_sushi_day1/sushi_plate.py` | `solutions/20_sushi_plate.py` |
+| 21 | data model methods, sequence behavior, comparison, and alternate constructors | `exercises/21_oop_sushi_data_model/conveyor_belt.py` | `solutions/21_conveyor_belt.py` |
+| 22 | `@classmethod`, inheritance, composition, ABCs, and polymorphism | `exercises/22_oop_sushi_creation_design/restaurant_design.py` | `solutions/22_restaurant_design.py` |
+| 23 | `@property`, dataclasses, `default_factory`, protocols, and swappable pricing | `exercises/23_oop_sushi_properties_solid/simulator.py` | `solutions/23_simulator.py` |
+

--- a/py03lings/README.md
+++ b/py03lings/README.md
@@ -16,6 +16,7 @@ A rustlings-style practice track for Python 3 fundamentals, async exercises, and
 - Work through 06-09 for dataclasses and validation.
 - Finish 10-15 for practical data engineering patterns (modeling, partitioning, orchestration, governance, and performance).
 - Use 16-19 to practice systems-minded Python: `__slots__`, `deque`, page/cache behavior, and scheduler time slices.
+- Use 20-23 for a four-part object-oriented Python mini-course that builds a sushi-conveyor simulator with classes, dunder methods, inheritance/composition, properties, dataclasses, and protocol-based design.
 
 ## Quick check commands
 

--- a/py03lings/exercises/20_oop_sushi_day1/sushi_plate.py
+++ b/py03lings/exercises/20_oop_sushi_day1/sushi_plate.py
@@ -1,0 +1,43 @@
+"""Exercise 20: refactor fragile sushi dictionaries into first-class objects.
+
+Day 1 focus:
+- decide when a named class earns its keep over a dict
+- write constructors with instance state
+- distinguish class attributes from instance attributes
+- avoid the mutable class attribute trap
+- make debugging pleasant with useful ``__repr__`` output
+"""
+
+
+class SushiPlate:
+    default_currency = "GBP"
+    # TODO: keep all mutable per-plate state on instances, not on the class.
+    # A shared class-level list would make every plate appear to have the same tags.
+
+    def __init__(self, name: str, color: str, price: float) -> None:
+        # TODO: store name, color, and price on this instance.
+        # TODO: create a fresh empty tags list for this instance.
+        pass
+
+    def add_tag(self, tag: str) -> None:
+        # TODO: append tag to this plate's tags.
+        pass
+
+    def __repr__(self) -> str:
+        # TODO: return a developer-friendly representation such as:
+        # SushiPlate(name='salmon nigiri', color='red', price=4.5)
+        return "SushiPlate()"
+
+
+def plate_from_dict(raw_plate: dict[str, object]) -> SushiPlate:
+    """Convert a loose restaurant dictionary into a named object."""
+    # TODO: read name, color, and price from raw_plate and return a SushiPlate.
+    return SushiPlate("TODO", "TODO", 0.0)
+
+
+if __name__ == "__main__":
+    plate = plate_from_dict({"name": "salmon nigiri", "color": "red", "price": 4.5})
+    plate.add_tag("popular")
+    other = SushiPlate("cucumber maki", "green", 3.0)
+    print(plate)
+    print(other.tags)  # should still be []

--- a/py03lings/exercises/21_oop_sushi_data_model/conveyor_belt.py
+++ b/py03lings/exercises/21_oop_sushi_data_model/conveyor_belt.py
@@ -1,0 +1,71 @@
+"""Exercise 21: make custom restaurant objects feel native to Python.
+
+Day 2 focus:
+- represent objects with ``__repr__`` and ``__str__``
+- make a custom container iterable, indexable, sizeable, and searchable
+- use comparison dunders so sorting works without a parallel API
+- use ``@classmethod`` as an alternate constructor
+"""
+
+from __future__ import annotations
+
+
+class MenuItem:
+    def __init__(self, name: str, price: float) -> None:
+        self.name = name
+        self.price = float(price)
+
+    @classmethod
+    def from_csv(cls, row: str) -> "MenuItem":
+        # TODO: parse a "name,price" row and return an item.
+        return cls("TODO", 0.0)
+
+    def __repr__(self) -> str:
+        # TODO: return MenuItem(name='...', price=...)
+        return "MenuItem()"
+
+    def __str__(self) -> str:
+        # TODO: return a customer-friendly label like "tuna roll (£5.00)".
+        return self.name
+
+    def __eq__(self, other: object) -> bool:
+        # TODO: compare by name and price; return NotImplemented for other types.
+        return False
+
+    def __lt__(self, other: "MenuItem") -> bool:
+        # TODO: sort cheaper items first, using name as the tie-breaker.
+        return False
+
+
+class ConveyorBelt:
+    def __init__(self, items: list[MenuItem] | None = None) -> None:
+        self._items = list(items or [])
+
+    def add(self, item: MenuItem) -> None:
+        self._items.append(item)
+
+    def __len__(self) -> int:
+        # TODO: make len(belt) work.
+        return 0
+
+    def __iter__(self):
+        # TODO: make for item in belt work.
+        return iter(())
+
+    def __getitem__(self, index: int) -> MenuItem:
+        # TODO: make belt[index] work.
+        raise IndexError(index)
+
+    def __contains__(self, name: object) -> bool:
+        # TODO: make "tuna roll" in belt check item names.
+        return False
+
+    def __add__(self, other: "ConveyorBelt") -> "ConveyorBelt":
+        # TODO: return a new belt containing items from both belts.
+        return ConveyorBelt()
+
+
+if __name__ == "__main__":
+    belt = ConveyorBelt([MenuItem.from_csv("tuna roll,5"), MenuItem.from_csv("edamame,2.5")])
+    print(len(belt), belt[0], "tuna roll" in belt)
+    print(sorted(belt))

--- a/py03lings/exercises/22_oop_sushi_creation_design/restaurant_design.py
+++ b/py03lings/exercises/22_oop_sushi_creation_design/restaurant_design.py
@@ -1,0 +1,72 @@
+"""Exercise 22: practice object creation, inheritance, composition, and ABCs.
+
+Day 3 focus:
+- provide named alternate constructors with ``@classmethod``
+- use inheritance for a true is-a relationship
+- use composition for has-one and has-many relationships
+- require subclass behavior with ``ABC`` and ``@abstractmethod``
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class Dish(ABC):
+    def __init__(self, name: str, base_price: float) -> None:
+        self.name = name
+        self.base_price = float(base_price)
+
+    @classmethod
+    def from_menu_row(cls, row: str) -> "Dish":
+        # TODO: parse "name|price" and construct cls(name, price).
+        return cls("TODO", 0.0)
+
+    @abstractmethod
+    def prep_time_minutes(self) -> int:
+        """Return the estimated preparation time."""
+
+    def price(self) -> float:
+        return self.base_price
+
+
+class Nigiri(Dish):
+    # TODO: implement prep_time_minutes() and return 4.
+    pass
+
+
+class MakiRoll(Dish):
+    # TODO: implement prep_time_minutes() and return 6.
+    pass
+
+
+class Chef:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class Restaurant:
+    def __init__(self, chef: Chef, dishes: list[Dish] | None = None) -> None:
+        # has-one composition: a restaurant has one chef.
+        self.chef = chef
+        # has-many composition: a restaurant has many dishes.
+        self.dishes = list(dishes or [])
+
+    def add_dish(self, dish: Dish) -> None:
+        # TODO: add dish to this restaurant's menu.
+        pass
+
+    def total_prep_time(self) -> int:
+        # TODO: sum prep time for all dishes.
+        return 0
+
+    def menu_names(self) -> list[str]:
+        # TODO: return the names of all dishes.
+        return []
+
+
+if __name__ == "__main__":
+    restaurant = Restaurant(Chef("Stephen"))
+    restaurant.add_dish(Nigiri.from_menu_row("salmon nigiri|4.5"))
+    restaurant.add_dish(MakiRoll.from_menu_row("avocado maki|3.5"))
+    print(restaurant.chef.name, restaurant.menu_names(), restaurant.total_prep_time())

--- a/py03lings/exercises/23_oop_sushi_properties_solid/simulator.py
+++ b/py03lings/exercises/23_oop_sushi_properties_solid/simulator.py
@@ -1,0 +1,78 @@
+"""Exercise 23: finish a lasting restaurant model with properties and SOLID.
+
+Day 4 focus:
+- use ``@property`` for read-only/computed values and validated setters
+- use ``@dataclass`` for small value objects
+- use ``field(default_factory=...)`` for mutable defaults
+- depend on a protocol so pricing behavior is swappable
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class OrderLine:
+    item_name: str
+    quantity: int
+    unit_price: float
+
+    @property
+    def subtotal(self) -> float:
+        # TODO: compute quantity * unit_price.
+        return 0.0
+
+
+class PricingPolicy(Protocol):
+    def price_for(self, base_price: float, hour: int) -> float:
+        """Return the effective price for this hour."""
+
+
+class StandardPricing:
+    def price_for(self, base_price: float, hour: int) -> float:
+        # TODO: standard pricing does not change the price.
+        return 0.0
+
+
+class HappyHourPricing:
+    def price_for(self, base_price: float, hour: int) -> float:
+        # TODO: give a 25% discount for orders from 16:00 through 17:59.
+        return 0.0
+
+
+@dataclass
+class OrderQueue:
+    lines: list[OrderLine] = field(default_factory=list)
+
+    def add(self, line: OrderLine) -> None:
+        # TODO: append a line to this queue.
+        pass
+
+    @property
+    def total(self) -> float:
+        # TODO: compute the total of all order lines.
+        return 0.0
+
+
+class RestaurantClock:
+    def __init__(self, hour: int) -> None:
+        self.hour = hour
+
+    @property
+    def hour(self) -> int:
+        return self._hour
+
+    @hour.setter
+    def hour(self, value: int) -> None:
+        # TODO: accept only integers from 0 through 23, then store on _hour.
+        self._hour = value
+
+
+if __name__ == "__main__":
+    clock = RestaurantClock(16)
+    policy: PricingPolicy = HappyHourPricing()
+    queue = OrderQueue()
+    queue.add(OrderLine("salmon nigiri", 2, policy.price_for(4.5, clock.hour)))
+    print(queue.total)

--- a/py03lings/solutions/20_sushi_plate.py
+++ b/py03lings/solutions/20_sushi_plate.py
@@ -1,0 +1,36 @@
+"""Solution 20: refactor fragile sushi dictionaries into first-class objects."""
+
+
+class SushiPlate:
+    default_currency = "GBP"
+
+    def __init__(self, name: str, color: str, price: float) -> None:
+        self.name = name
+        self.color = color
+        self.price = float(price)
+        self.tags: list[str] = []
+
+    def add_tag(self, tag: str) -> None:
+        self.tags.append(tag)
+
+    def __repr__(self) -> str:
+        return (
+            f"SushiPlate(name={self.name!r}, color={self.color!r}, "
+            f"price={self.price!r})"
+        )
+
+
+def plate_from_dict(raw_plate: dict[str, object]) -> SushiPlate:
+    return SushiPlate(
+        name=str(raw_plate["name"]),
+        color=str(raw_plate["color"]),
+        price=float(raw_plate["price"]),
+    )
+
+
+if __name__ == "__main__":
+    plate = plate_from_dict({"name": "salmon nigiri", "color": "red", "price": 4.5})
+    plate.add_tag("popular")
+    other = SushiPlate("cucumber maki", "green", 3.0)
+    print(plate)
+    print(other.tags)

--- a/py03lings/solutions/21_conveyor_belt.py
+++ b/py03lings/solutions/21_conveyor_belt.py
@@ -1,0 +1,59 @@
+"""Solution 21: make custom restaurant objects feel native to Python."""
+
+from __future__ import annotations
+
+
+class MenuItem:
+    def __init__(self, name: str, price: float) -> None:
+        self.name = name
+        self.price = float(price)
+
+    @classmethod
+    def from_csv(cls, row: str) -> "MenuItem":
+        name, raw_price = row.split(",", maxsplit=1)
+        return cls(name.strip(), float(raw_price))
+
+    def __repr__(self) -> str:
+        return f"MenuItem(name={self.name!r}, price={self.price!r})"
+
+    def __str__(self) -> str:
+        return f"{self.name} (£{self.price:.2f})"
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, MenuItem):
+            return NotImplemented
+        return (self.name, self.price) == (other.name, other.price)
+
+    def __lt__(self, other: "MenuItem") -> bool:
+        return (self.price, self.name) < (other.price, other.name)
+
+
+class ConveyorBelt:
+    def __init__(self, items: list[MenuItem] | None = None) -> None:
+        self._items = list(items or [])
+
+    def add(self, item: MenuItem) -> None:
+        self._items.append(item)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __iter__(self):
+        return iter(self._items)
+
+    def __getitem__(self, index: int) -> MenuItem:
+        return self._items[index]
+
+    def __contains__(self, name: object) -> bool:
+        if not isinstance(name, str):
+            return False
+        return any(item.name == name for item in self._items)
+
+    def __add__(self, other: "ConveyorBelt") -> "ConveyorBelt":
+        return ConveyorBelt([*self._items, *other._items])
+
+
+if __name__ == "__main__":
+    belt = ConveyorBelt([MenuItem.from_csv("tuna roll,5"), MenuItem.from_csv("edamame,2.5")])
+    print(len(belt), belt[0], "tuna roll" in belt)
+    print(sorted(belt))

--- a/py03lings/solutions/22_restaurant_design.py
+++ b/py03lings/solutions/22_restaurant_design.py
@@ -1,0 +1,60 @@
+"""Solution 22: practice object creation, inheritance, composition, and ABCs."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class Dish(ABC):
+    def __init__(self, name: str, base_price: float) -> None:
+        self.name = name
+        self.base_price = float(base_price)
+
+    @classmethod
+    def from_menu_row(cls, row: str) -> "Dish":
+        name, raw_price = row.split("|", maxsplit=1)
+        return cls(name.strip(), float(raw_price))
+
+    @abstractmethod
+    def prep_time_minutes(self) -> int:
+        """Return the estimated preparation time."""
+
+    def price(self) -> float:
+        return self.base_price
+
+
+class Nigiri(Dish):
+    def prep_time_minutes(self) -> int:
+        return 4
+
+
+class MakiRoll(Dish):
+    def prep_time_minutes(self) -> int:
+        return 6
+
+
+class Chef:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class Restaurant:
+    def __init__(self, chef: Chef, dishes: list[Dish] | None = None) -> None:
+        self.chef = chef
+        self.dishes = list(dishes or [])
+
+    def add_dish(self, dish: Dish) -> None:
+        self.dishes.append(dish)
+
+    def total_prep_time(self) -> int:
+        return sum(dish.prep_time_minutes() for dish in self.dishes)
+
+    def menu_names(self) -> list[str]:
+        return [dish.name for dish in self.dishes]
+
+
+if __name__ == "__main__":
+    restaurant = Restaurant(Chef("Stephen"))
+    restaurant.add_dish(Nigiri.from_menu_row("salmon nigiri|4.5"))
+    restaurant.add_dish(MakiRoll.from_menu_row("avocado maki|3.5"))
+    print(restaurant.chef.name, restaurant.menu_names(), restaurant.total_prep_time())

--- a/py03lings/solutions/23_simulator.py
+++ b/py03lings/solutions/23_simulator.py
@@ -1,0 +1,71 @@
+"""Solution 23: finish a lasting restaurant model with properties and SOLID."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class OrderLine:
+    item_name: str
+    quantity: int
+    unit_price: float
+
+    @property
+    def subtotal(self) -> float:
+        return self.quantity * self.unit_price
+
+
+class PricingPolicy(Protocol):
+    def price_for(self, base_price: float, hour: int) -> float:
+        """Return the effective price for this hour."""
+
+
+class StandardPricing:
+    def price_for(self, base_price: float, hour: int) -> float:
+        return base_price
+
+
+class HappyHourPricing:
+    def price_for(self, base_price: float, hour: int) -> float:
+        if 16 <= hour < 18:
+            return base_price * 0.75
+        return base_price
+
+
+@dataclass
+class OrderQueue:
+    lines: list[OrderLine] = field(default_factory=list)
+
+    def add(self, line: OrderLine) -> None:
+        self.lines.append(line)
+
+    @property
+    def total(self) -> float:
+        return sum(line.subtotal for line in self.lines)
+
+
+class RestaurantClock:
+    def __init__(self, hour: int) -> None:
+        self.hour = hour
+
+    @property
+    def hour(self) -> int:
+        return self._hour
+
+    @hour.setter
+    def hour(self, value: int) -> None:
+        if not isinstance(value, int):
+            raise TypeError("hour must be an integer")
+        if not 0 <= value <= 23:
+            raise ValueError("hour must be between 0 and 23")
+        self._hour = value
+
+
+if __name__ == "__main__":
+    clock = RestaurantClock(16)
+    policy: PricingPolicy = HappyHourPricing()
+    queue = OrderQueue()
+    queue.add(OrderLine("salmon nigiri", 2, policy.price_for(4.5, clock.hour)))
+    print(queue.total)


### PR DESCRIPTION
### Motivation
- Introduce a compact, four-day Object-Oriented Python mini-course into the py03lings track using a sushi-conveyor simulator as a concrete project.
- Teach practical OOP design and Pythonic data model features (constructors, `__repr__`, dunder methods, inheritance vs composition, `@property`, `@dataclass`, and protocol-based design) in exercises that surface real design decisions.
- Provide hands-on student exercises with matching solution implementations so instructors and learners can code-along and verify behavior.

### Description
- Add a new OOP section to `py03lings/EXERCISES.md` and note the new path in `py03lings/README.md` mapping exercises 20–23 to their solution files. 
- Add exercise skeletons with TODOs at `py03lings/exercises/20_oop_sushi_day1/sushi_plate.py`, `py03lings/exercises/21_oop_sushi_data_model/conveyor_belt.py`, `py03lings/exercises/22_oop_sushi_creation_design/restaurant_design.py`, and `py03lings/exercises/23_oop_sushi_properties_solid/simulator.py`. 
- Add fully implemented reference solutions at `py03lings/solutions/20_sushi_plate.py`, `py03lings/solutions/21_conveyor_belt.py`, `py03lings/solutions/22_restaurant_design.py`, and `py03lings/solutions/23_simulator.py`. 
- Exercises focus respectively on: classes/instance state and `__repr__`, Python data model and sequence-like behavior, alternate constructors/ABC-based inheritance and composition, and `@property`/`@dataclass`/protocol-based swappable pricing.

### Testing
- Ran `python py03lings/check.py` to enumerate TODOs and validate exercise structure, which executed successfully. 
- Ran `python -m compileall py03lings/exercises py03lings/solutions` to byte-compile the new modules, which succeeded with no syntax errors. 
- Executed each solution script with `python py03lings/solutions/20_sushi_plate.py`, `python py03lings/solutions/21_conveyor_belt.py`, `python py03lings/solutions/22_restaurant_design.py`, and `python py03lings/solutions/23_simulator.py`, and each printed the expected sample output. 
- No automated tests failed during the checks described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1eee692968832eb472980775d57be0)